### PR TITLE
USB single-task rework, pipeline hardening, multi-version build, gated power-hours odometer

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -6,25 +6,33 @@ set(FREERTOS_PORT "TEMPLATE" CACHE STRING "" FORCE)
 # New in SDK 2.1.1, use the fastest supported clock
 set(PICO_USE_FASTEST_SUPPORTED_CLOCK 1)
 
-# Which version our code is written for
+# Which hardware version(s) our code is built for.
+#
+# By default we build every supported version (2, 3, 4) in a single
+# configuration. Set HARDWARE_VERSION (as a CMake -D or an environment
+# variable) to narrow the build to a single version - this keeps every
+# existing workflow and CLion profile working unchanged.
+#
+# The CC_VERx defines are intentionally NOT set globally here. They are applied
+# per-target in create_firmware() so that multiple versions can coexist in one
+# CMake configuration.
 if (NOT DEFINED HARDWARE_VERSION AND DEFINED ENV{HARDWARE_VERSION})
     set(HARDWARE_VERSION $ENV{HARDWARE_VERSION})
 endif()
 
-if (HARDWARE_VERSION STREQUAL "2")
-    message("HARDWARE_VERSION is set to ${HARDWARE_VERSION}, setting CC_VER2=1")
-    add_compile_definitions(CC_VER2=1)
-elseif (HARDWARE_VERSION STREQUAL "4")
-    message("HARDWARE_VERSION is set to 4, setting CC_VER4=1 and CC_VER3=1")
-    add_compile_definitions(CC_VER4=1 CC_VER3=1)
-elseif (HARDWARE_VERSION STREQUAL "3")
-    message("HARDWARE_VERSION is set to 3, setting CC_VER3=1")
-    add_compile_definitions(CC_VER3=1)
+if (DEFINED HARDWARE_VERSION)
+    set(HARDWARE_VERSIONS ${HARDWARE_VERSION})
+    message("HARDWARE_VERSION is set to ${HARDWARE_VERSION}; building only that version")
 else()
-    message("HARDWARE_VERSION not set, defaulting to 4")
-    set(HARDWARE_VERSION 4)
-    add_compile_definitions(CC_VER4=1 CC_VER3=1)
+    set(HARDWARE_VERSIONS 2 3 4)
+    message("HARDWARE_VERSION not set; building all supported versions: ${HARDWARE_VERSIONS}")
 endif()
+
+foreach(_hw_version IN LISTS HARDWARE_VERSIONS)
+    if (NOT _hw_version MATCHES "^[234]$")
+        message(FATAL_ERROR "Unsupported HARDWARE_VERSION '${_hw_version}' (expected 2, 3, or 4)")
+    endif()
+endforeach()
 
 
 
@@ -63,7 +71,7 @@ endif()
 message("Building for platform ${PICO_PLATFORM}")
 
 project(creature-firmware
-        VERSION "4.0.0"
+        VERSION "4.1.0"
         DESCRIPTION "Pi Pico Firmwares for April's Creatures"
         HOMEPAGE_URL https://github.com/opsnlops/creature-controller/firmware
         LANGUAGES C CXX ASM)
@@ -123,6 +131,8 @@ set(COMMON_SOURCES
         src/device/colors.c
         src/device/eeprom.h
         src/device/eeprom.c
+        src/device/eeprom_hours.h
+        src/device/eeprom_hours.c
         src/device/mcp3304.h
         src/device/mcp3304.c
         src/device/mcp9808.h
@@ -249,10 +259,9 @@ set(DYNAMIXEL_SOURCES
         src/dynamixel/dynamixel_servo.c
 )
 
-# Include Dynamixel sources for VER4 controller builds
-if (HARDWARE_VERSION STREQUAL "4")
-    list(APPEND CONTROLLER_ADDITIONAL_SOURCES ${DYNAMIXEL_SOURCES})
-endif()
+# The controller pulls in the Dynamixel stack only on v4 hardware. This is
+# applied per-version inside the firmware-creation loop below, so it cannot be
+# appended to the shared source list here.
 
 # Dynamixel Servo Tester
 set(DYNAMIXEL_TESTER_ADDITIONAL_SOURCES
@@ -276,12 +285,26 @@ set(DYNAMIXEL_TESTER_ADDITIONAL_INCLUDES
 
 
 # Function to create firmware targets
-function(create_firmware TARGET_NAME ADDITIONAL_SOURCES ADDITIONAL_LIBS ADDITIONAL_INCLUDES)
+function(create_firmware TARGET_NAME HW_VERSION ADDITIONAL_SOURCES ADDITIONAL_LIBS ADDITIONAL_INCLUDES)
     add_executable(${TARGET_NAME}
             ${COMMON_SOURCES}
             ${ADDITIONAL_SOURCES}
             FreeRTOSConfig.h
     )
+
+    # Per-target hardware-version selection. These were previously global
+    # add_compile_definitions(); making them per-target is what lets all
+    # versions coexist in a single CMake configuration. The semantics are
+    # identical to before: v4 hardware is a superset of v3.
+    if (HW_VERSION STREQUAL "2")
+        target_compile_definitions(${TARGET_NAME} PRIVATE CC_VER2=1)
+    elseif (HW_VERSION STREQUAL "3")
+        target_compile_definitions(${TARGET_NAME} PRIVATE CC_VER3=1)
+    elseif (HW_VERSION STREQUAL "4")
+        target_compile_definitions(${TARGET_NAME} PRIVATE CC_VER4=1 CC_VER3=1)
+    else()
+        message(FATAL_ERROR "create_firmware: unsupported HW_VERSION '${HW_VERSION}'")
+    endif()
 
     pico_generate_pio_header(${TARGET_NAME} ${CMAKE_CURRENT_LIST_DIR}/src/io/uart_rx.pio OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/generated)
     pico_generate_pio_header(${TARGET_NAME} ${CMAKE_CURRENT_LIST_DIR}/src/io/uart_tx.pio OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR}/generated)
@@ -305,27 +328,37 @@ endfunction()
 
 
 
-# Create firmware targets
-create_firmware("controller-${PICO_PLATFORM}-hw${HARDWARE_VERSION}"
-        "${CONTROLLER_ADDITIONAL_SOURCES}"
-        "${CONTROLLER_ADDITIONAL_LIBS}"
-        "${CONTROLLER_ADDITIONAL_INCLUDES}"
-)
+# Create the full set of firmware targets for every requested hardware version.
+foreach(V IN LISTS HARDWARE_VERSIONS)
 
-create_firmware("usbc_pd-${PICO_PLATFORM}-hw${HARDWARE_VERSION}"
-        "${USBC_PD_ADDITIONAL_SOURCES}"
-        "${USBC_PD_ADDITIONAL_LIBS}"
-        "${USBC_PD_ADDITIONAL_INCLUDES}"
-)
+    # The controller pulls in the Dynamixel stack only on v4 hardware.
+    set(CONTROLLER_SOURCES_FOR_VERSION ${CONTROLLER_ADDITIONAL_SOURCES})
+    if (V STREQUAL "4")
+        list(APPEND CONTROLLER_SOURCES_FOR_VERSION ${DYNAMIXEL_SOURCES})
+    endif()
 
-create_firmware("programmer-${PICO_PLATFORM}-hw${HARDWARE_VERSION}"
-        "${PROGRAMMER_ADDITIONAL_SOURCES}"
-        "${PROGRAMMER_ADDITIONAL_LIBS}"
-        "${PROGRAMMER_ADDITIONAL_INCLUDES}"
-)
+    create_firmware("controller-${PICO_PLATFORM}-hw${V}" "${V}"
+            "${CONTROLLER_SOURCES_FOR_VERSION}"
+            "${CONTROLLER_ADDITIONAL_LIBS}"
+            "${CONTROLLER_ADDITIONAL_INCLUDES}"
+    )
 
-create_firmware("dynamixel-tester-${PICO_PLATFORM}-hw${HARDWARE_VERSION}"
-        "${DYNAMIXEL_TESTER_ADDITIONAL_SOURCES}"
-        "${DYNAMIXEL_TESTER_ADDITIONAL_LIBS}"
-        "${DYNAMIXEL_TESTER_ADDITIONAL_INCLUDES}"
-)
+    create_firmware("usbc_pd-${PICO_PLATFORM}-hw${V}" "${V}"
+            "${USBC_PD_ADDITIONAL_SOURCES}"
+            "${USBC_PD_ADDITIONAL_LIBS}"
+            "${USBC_PD_ADDITIONAL_INCLUDES}"
+    )
+
+    create_firmware("programmer-${PICO_PLATFORM}-hw${V}" "${V}"
+            "${PROGRAMMER_ADDITIONAL_SOURCES}"
+            "${PROGRAMMER_ADDITIONAL_LIBS}"
+            "${PROGRAMMER_ADDITIONAL_INCLUDES}"
+    )
+
+    create_firmware("dynamixel-tester-${PICO_PLATFORM}-hw${V}" "${V}"
+            "${DYNAMIXEL_TESTER_ADDITIONAL_SOURCES}"
+            "${DYNAMIXEL_TESTER_ADDITIONAL_LIBS}"
+            "${DYNAMIXEL_TESTER_ADDITIONAL_INCLUDES}"
+    )
+
+endforeach()

--- a/firmware/docs/opt-os-freertos-migration.md
+++ b/firmware/docs/opt-os-freertos-migration.md
@@ -1,0 +1,114 @@
+# Planned change: TinyUSB `OPT_OS_NONE` → `OPT_OS_FREERTOS`
+
+Status: **planned, not started.** Do this as its own isolated, hardware-verified
+change — not bundled with anything else.
+
+## Why
+
+The most latency-critical thing this firmware does is *receiving* host position
+commands every 20 ms (50 Hz). The standard-servo path has no control task: the
+PWM-wrap ISR consumes `motor_map[].requested_position` directly, written by
+`processMessage()` in the inbound chain.
+
+Today (`CFG_TUSB_OS = OPT_OS_NONE`, `src/tusb_config.h`) `tud_task()` only runs
+on the `usb_device_task` poll cadence (`USB_DEVICE_TASK_POLL_MS = 1 ms`), so
+`tud_cdc_rx_cb` sees an inbound packet up to ~1 ms after the USB IRQ latched it
+(worse if the priority-31 timer daemon is mid blocking-I²C). A consistent ~1 ms
+is a harmless phase offset against a 20 ms budget; the concern is *jitter*
+occasionally pushing a command past a PWM-wrap deadline (one stale servo
+frame).
+
+`OPT_OS_FREERTOS` makes the USB dcd ISR signal TinyUSB's internal FreeRTOS
+queue, waking the USB task on packet arrival → RX serviced in ≈ISR + context
+switch (tens of µs), decoupled from the poll cadence and the TX/telemetry tail.
+This is a real-time determinism improvement, not just CPU savings.
+
+Already done as the cheap first step (shipped separately): the inbound parse
+chain was raised from priority 1 to `INCOMING_RX_TASK_PRIORITY` (5). That
+removes the largest jitter source (the parse chain being starvable by
+everything). `OPT_OS_FREERTOS` is the second, deeper step.
+
+## The design problem (this is not a config flip)
+
+The clean `OPT_OS_FREERTOS` pattern is one task doing `while (1) tud_task();`
+that blocks on TinyUSB's internal event queue. But `usb_device_task` has a
+**second wake source TinyUSB knows nothing about**: the
+`usb_serial_outgoing_messages` queue it drains for CDC TX. Naive options all
+fail:
+
+- keep the 1 ms `vTaskDelay` poll → no benefit, just added risk;
+- block only on TinyUSB's event queue → outbound CDC stalls until the next USB
+  event;
+- move CDC writes back to another context → reintroduces the multi-context
+  hazard we eliminated (the whole point of the single-task design).
+
+Required design: the USB task must wake on **either** a USB event **or**
+"app has outbound data," while still being the sole caller of every `tud_*`.
+
+### Approach
+
+1. `CFG_TUSB_OS = OPT_OS_FREERTOS` in `src/tusb_config.h` (verify the TinyUSB
+   FreeRTOS OSAL compiles/links under pico-sdk 2.2 + this FreeRTOS-Kernel).
+2. Keep `usb_device_task` as the single owner of all `tud_*`. Restructure its
+   loop to block efficiently instead of `vTaskDelay(1 ms)` polling:
+   - Wait with a bounded timeout (e.g. the connection-check interval) on a
+     FreeRTOS **task notification**.
+   - `send_to_controller`'s USB stage (the `usb_serial_outgoing_messages`
+     enqueue) additionally does `xTaskNotifyGive(usb_device_task_handle)` so a
+     newly queued outbound message wakes the USB task immediately.
+   - TinyUSB's own RX/event path wakes `tud_task()` via the FreeRTOS OSAL.
+   - On wake: `tud_task()`, then the existing bounded TX burst-drain, then the
+     periodic connection check. The bounded timeout still bounds the
+     connection-check cadence and is a safety net if a notification is missed.
+3. The TX burst-drain, stuck-message drop (`USB_TX_STALL_LIMIT`), and
+   disconnect-discard logic carry over unchanged — they are already correct
+   and non-blocking.
+
+## The hard gotcha: USB IRQ priority
+
+With `OPT_OS_FREERTOS` the rp2350 dcd ISR calls `FromISR` OSAL APIs. They are
+only legal if `USBCTRL_IRQ` priority is **numerically ≥
+`configMAX_SYSCALL_INTERRUPT_PRIORITY` (0xA0 here)** — i.e. maskable by FreeRTOS
+critical sections. The pico-sdk default IRQ priority is `0x80` (above the
+ceiling) → a `FromISR` call from the USB IRQ at default priority is illegal and
+causes intermittent `configASSERT`/hard faults.
+
+Action: explicitly `irq_set_priority(USBCTRL_IRQ, <value ≥ 0xA0>)` during USB
+init, and confirm it is applied *after* anything that might reset it. This is
+the single highest-risk item and is a timing-dependent failure, not a
+log-readable one — it must be verified on hardware under load.
+
+## Risks
+
+- USB IRQ priority (above) — hard-fault class if wrong.
+- TinyUSB FreeRTOS OSAL build/link integration under this exact pico-sdk /
+  FreeRTOS-Kernel pairing.
+- Missed-notification deadlock: the bounded wait timeout is the mandatory
+  safety net — never wait forever on the notification alone.
+- Behavior parity for the TX burst / stall-drop / disconnect-discard paths.
+
+## Verification plan (do not skip — this is the lesson from the splice saga)
+
+1. Build the full hw2/3/4 matrix clean.
+2. Flash hw3 (or hw4) on the **production Linux host**.
+3. Raw-reader capture (`tools/raw_cdc_capture.py`), splice-check = 0.
+4. Soak: confirm `STATS` `OUT_DROP`/`IN_DROP` stay sane and `usb_tx_fifo_full`
+   does not climb pathologically.
+5. RX-latency check: instrument time from `tud_cdc_rx_cb` enqueue to
+   `processMessage` (or compare position-command application jitter) before vs
+   after; expect the ~1 ms poll component to disappear.
+6. Stress: hammer inbound position messages while saturating outbound
+   telemetry; confirm no hard faults (validates the USB IRQ priority) and no
+   stalls.
+
+## Rollback
+
+Single revert: `CFG_TUSB_OS` back to `OPT_OS_NONE` + restore the
+`vTaskDelay`-paced loop. Keep the change isolated in `tusb_config.h` + `usb.c`
+so rollback is one commit.
+
+## Sequencing
+
+1. (done) Raise inbound parse chain to `INCOMING_RX_TASK_PRIORITY`.
+2. Land + soak the single-task `OPT_OS_NONE` design in production.
+3. Then this migration, isolated and hardware-verified per the plan above.

--- a/firmware/src/controller/config.h
+++ b/firmware/src/controller/config.h
@@ -45,6 +45,17 @@
  * These values are hardware-version independent, so they live here outside the
  * CC_VERx guards. That also lets the host unit tests pull them in directly.
  */
+
+// Master enable for the power-on hours odometer. OFF by default: on current
+// CC_VER3 boards the 24FC256 WP pin is tied to 3V3 (active-high write-protect),
+// so the EEPROM array is read-only at runtime - the 15-minute persist writes
+// are silently inhibited and UP_HRS/MTR_HRS reset to 0 on every boot. Enable
+// this only on a board revision where WP is GPIO-controlled (or tied low).
+// The pure record logic still builds and is unit-tested regardless of this
+// switch; this only gates the runtime feature (boot restore, persist timer,
+// motor sampling, and the UP_HRS/MTR_HRS STATS fields).
+#define USE_POWER_HOURS 0
+
 #define EEPROM_TOTAL_SIZE 32768      // 24C256-class part: 32 KB
 #define EEPROM_HOURS_REGION_SIZE 256 // Bytes reserved at the top
 #define EEPROM_HOURS_REGION_ADDR (EEPROM_TOTAL_SIZE - EEPROM_HOURS_REGION_SIZE)

--- a/firmware/src/controller/config.h
+++ b/firmware/src/controller/config.h
@@ -34,6 +34,31 @@
 #define POWER_PIN 28
 
 /*
+ * Power-on hours odometer
+ *
+ * Two lifetime counters persisted to the I2C EEPROM: total controller uptime,
+ * and the time the motor power rail has been energized. They live in a
+ * wear-leveled ring at the very top of the EEPROM, well clear of the
+ * personality block (which is written from address 0 and is only a few dozen
+ * bytes long).
+ *
+ * These values are hardware-version independent, so they live here outside the
+ * CC_VERx guards. That also lets the host unit tests pull them in directly.
+ */
+#define EEPROM_TOTAL_SIZE 32768      // 24C256-class part: 32 KB
+#define EEPROM_HOURS_REGION_SIZE 256 // Bytes reserved at the top
+#define EEPROM_HOURS_REGION_ADDR (EEPROM_TOTAL_SIZE - EEPROM_HOURS_REGION_SIZE)
+#define EEPROM_HOURS_SLOT_SIZE 16 // One record; fits within a page
+#define EEPROM_HOURS_SLOT_COUNT (EEPROM_HOURS_REGION_SIZE / EEPROM_HOURS_SLOT_SIZE)
+#define EEPROM_HOURS_MAGIC 0x4852                         // 'H','R' - an hours record
+#define EEPROM_HOURS_PERSIST_INTERVAL_MS (15 * 60 * 1000) // Persist every 15 minutes
+#define EEPROM_WRITE_CYCLE_MS 10                          // EEPROM internal write-cycle wait
+
+// The motor power rail is considered "on" once the incoming-motor-power
+// PAC1954 channel reads above this many volts.
+#define MOTOR_POWER_ON_VOLTAGE_THRESHOLD 3.0f
+
+/*
  * EEPROM Config
  */
 
@@ -196,8 +221,48 @@
 #define USB_SERIAL_INCOMING_QUEUE_LENGTH 5
 #define USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH 128
 
+// Max bytes drained from the CDC RX FIFO per chunk. Bounds the inbound
+// callback's stack usage (it runs in the timer daemon) - never use a
+// FIFO-sized VLA there.
+#define USB_SERIAL_RX_CHUNK 64
+
 #define USB_SERIAL_OUTGOING_QUEUE_LENGTH 15
 #define USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH 384
+
+// TinyUSB is built CFG_TUSB_OS=OPT_OS_NONE, which is only safe when a SINGLE
+// context drives the device stack and all CDC writes. usb_device_task owns
+// every tud_* call: it pumps tud_task() and drains the outgoing queue itself.
+// No mutex, no timers, no second context - so no FIFO/endpoint race.
+#define USB_DEVICE_TASK_STACK_SIZE 2048 // Words; covers tud_task() + a tx slot
+#define USB_DEVICE_TASK_PRIORITY 4      // Above workers(1)/control(2); it yields every loop
+#define USB_DEVICE_TASK_POLL_MS 1       // tud_task() cadence (matches the old 1 ms timer)
+#define USB_CDC_CONNECTION_CHECK_MS 100 // CDC connect/disconnect poll cadence
+#define USB_TX_BURST_MAX 8              // Max queued messages drained per task tick
+#define USB_TX_STALL_LIMIT 200          // Ticks one message may make zero progress before it's dropped
+
+/*
+ * FreeRTOS task priority map (configMAX_PRIORITIES = 32)
+ *
+ *   31  timer daemon (configTIMER_TASK_PRIORITY) - sensors, stats, odometer
+ *    5  INCOMING_RX_TASK_PRIORITY - the inbound parse chain (see below)
+ *    4  USB_DEVICE_TASK_PRIORITY  - tud_task() + CDC TX
+ *    2  DXL_TASK_PRIORITY         - Dynamixel 50 Hz sync (CC_VER4)
+ *    1  everything else           - logging, outbound telemetry, status LEDs
+ *
+ * The standard-servo real-time path has NO control task: the PWM-wrap ISR
+ * consumes motor_map[].requested_position directly, and that field is written
+ * by processMessage() running in the inbound chain
+ * (incoming_usb_serial_reader_task -> incoming_message_processor_task).
+ * Receiving and parsing host position commands every 20 ms is the most
+ * latency-critical thing this firmware does, so that chain runs just above the
+ * USB task - a freshly received line is parsed immediately rather than behind
+ * the USB task's telemetry-TX tail or the dxl task. It is safe: the chain
+ * blocks on its queues when idle (cannot starve lower tasks), and the only
+ * shared lock (motor_map_mutex) is a priority-inheriting FreeRTOS mutex with
+ * short critical sections. Servo output timing is a hardware ISR and is
+ * unaffected by task priority regardless.
+ */
+#define INCOMING_RX_TASK_PRIORITY 5
 
 /*
  * UART Serial Config

--- a/firmware/src/controller/config.h
+++ b/firmware/src/controller/config.h
@@ -21,6 +21,21 @@
 #define WATCHDOG_TIMEOUT_MS 5000
 #define PWM_WRAPS_PER_WATCHDOG_UPDATE 100
 
+// Watchdog health gate. The PWM-wrap ISR refreshes the hardware watchdog, but
+// that ISR runs off the PWM hardware IRQ independent of the FreeRTOS scheduler
+// - so a fully deadlocked/starved firmware still gets petted and never resets.
+// When this is enabled, the ISR refreshes the watchdog ONLY if a lowest-
+// priority heartbeat task has run since the last refresh, so a hung scheduler
+// actually resets the board. It gates purely on scheduler liveness, never on
+// host/comms activity, so a legitimately idle creature (no host, no commands)
+// is NOT reset. OFF by default until soaked on hardware (including a host-
+// disconnect soak and a deliberate-hang test); when 0, the refresh is
+// unconditional - byte-for-byte the original behavior.
+#define USE_WATCHDOG_HEALTH_GATE 0
+#define WATCHDOG_HEARTBEAT_PERIOD_MS 500   // Lowest-prio liveness beat (<< pet interval)
+#define WATCHDOG_HEARTBEAT_TASK_STACK 256  // Words; the task only sets a flag
+#define WATCHDOG_HEARTBEAT_TASK_PRIORITY 1 // tskIDLE_PRIORITY+1: proves the scheduler isn't starved
+
 // Light to flash when commands are being received
 // #define CDC_ACTIVE_PIN                      17
 

--- a/firmware/src/controller/controller.c
+++ b/firmware/src/controller/controller.c
@@ -13,6 +13,7 @@
 #include "io/message_processor.h"
 #include "io/responsive_analog_read_filter.h"
 #include "logging/logging.h"
+#include "watchdog/watchdog.h"
 
 #include "config.h"
 #include "controller.h"
@@ -363,11 +364,14 @@ void __isr on_pwm_wrap_handler() {
     pwm_clear_irq(motor_map[0].slice);
     number_of_pwm_wraps = number_of_pwm_wraps + 1;
 
-    // Update the watchdog every PWM_WRAPS_PER_WATCHDOG_UPDATE wraps
+    // Refresh the watchdog every PWM_WRAPS_PER_WATCHDOG_UPDATE wraps.
+    // watchdog_feed() applies the health gate (see USE_WATCHDOG_HEALTH_GATE):
+    // it refreshes only if the scheduler proved liveness, so a hung scheduler
+    // resets the board instead of this ISR petting it forever.
     watchdog_wrap_count++;
     if (watchdog_wrap_count >= PWM_WRAPS_PER_WATCHDOG_UPDATE) {
         watchdog_wrap_count = 0;
-        watchdog_update();
+        watchdog_feed();
     }
 }
 

--- a/firmware/src/controller/main.c
+++ b/firmware/src/controller/main.c
@@ -199,7 +199,9 @@ void initialize_eeprom(void) {
     bi_decl(bi_2pins_with_func(EEPROM_SDA_PIN, EEPROM_SCL_PIN, GPIO_FUNC_I2C))
     eeprom_setup_i2c();
     read_eeprom_and_configure();
+#if USE_POWER_HOURS
     eeprom_hours_init();
+#endif
     usb_descriptors_init();
 #else
     // Mark the build as not having EEPROM enabled
@@ -356,7 +358,7 @@ static bool initialize_status_and_monitoring(void) {
     start_stats_reporter();
     debug("Stats reporter started");
 
-#if USE_EEPROM
+#if USE_POWER_HOURS
     // Start the power-on hours odometer's periodic persist timer
     eeprom_hours_start();
     debug("Power-on hours odometer started");

--- a/firmware/src/controller/main.c
+++ b/firmware/src/controller/main.c
@@ -199,6 +199,7 @@ void initialize_eeprom(void) {
     bi_decl(bi_2pins_with_func(EEPROM_SDA_PIN, EEPROM_SCL_PIN, GPIO_FUNC_I2C))
     eeprom_setup_i2c();
     read_eeprom_and_configure();
+    eeprom_hours_init();
     usb_descriptors_init();
 #else
     // Mark the build as not having EEPROM enabled
@@ -354,6 +355,12 @@ static bool initialize_status_and_monitoring(void) {
     // Fire up the stats reporter
     start_stats_reporter();
     debug("Stats reporter started");
+
+#if USE_EEPROM
+    // Start the power-on hours odometer's periodic persist timer
+    eeprom_hours_start();
+    debug("Power-on hours odometer started");
+#endif
 
 #if USE_SENSORS
     bi_decl(bi_2pins_with_func(SENSORS_I2C_SDA_PIN, SENSORS_I2C_SCL_PIN, GPIO_FUNC_I2C))

--- a/firmware/src/controller/main.c
+++ b/firmware/src/controller/main.c
@@ -124,6 +124,9 @@ int main() {
         debug("Watchdog init'ed successfully");
     }
 
+    // Start the watchdog health-gate heartbeat (no-op unless USE_WATCHDOG_HEALTH_GATE)
+    watchdog_health_start();
+
     info("All systems initialized, starting scheduler");
 
     // Start the FreeRTOS scheduler - this should never return

--- a/firmware/src/debug/stats_reporter.c
+++ b/firmware/src/debug/stats_reporter.c
@@ -86,7 +86,7 @@ void statsReportTimerCallback(TimerHandle_t xTimer) {
         (unsigned long)incoming_messages_dropped, (unsigned long)position_messages_processed,
         (unsigned long)number_of_pwm_wraps, board_temperature);
 
-#if USE_EEPROM
+#if USE_POWER_HOURS
     // Append the lifetime power-on hours odometer (uptime and motor-powered)
     {
         size_t hours_len = strlen(message);

--- a/firmware/src/debug/stats_reporter.c
+++ b/firmware/src/debug/stats_reporter.c
@@ -7,8 +7,10 @@
 #include <task.h>
 #include <timers.h>
 
+#include "controller/config.h"
 #include "controller/controller.h"
 #include "debug/stats_reporter.h"
+#include "device/eeprom_hours.h"
 #include "io/message_processor.h"
 
 #ifdef CC_VER4
@@ -30,6 +32,11 @@ extern volatile u64 number_of_pwm_wraps;
 // From the message processor
 extern volatile u64 message_processor_messages_received;
 extern volatile u64 message_processor_messages_sent;
+
+// Pipeline drop counters - non-zero means the host isn't draining fast enough,
+// not that the pipeline stalled (it never blocks).
+extern volatile u64 outgoing_messages_dropped;
+extern volatile u64 incoming_messages_dropped;
 
 // From the UART
 extern volatile u64 uart_characters_received;
@@ -68,14 +75,25 @@ void statsReportTimerCallback(TimerHandle_t xTimer) {
     snprintf(
         message, USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH,
         "STATS\tHEAP_FREE %lu\tUSB_CRECV %lu\tUSB_MRECV %lu\tUSB_SENT %lu\tUART_CRECV %lu\tUART_MRECV %lu\tUART_SENT "
-        "%lu\tMP_RECV %lu\tMP_SENT %lu\tS_PARSE %lu\tF_PARSE %lu\tCHKFAIL %lu\tPOS_PROC %lu\tPWM_WRAPS %lu\tTEMP %.2f",
+        "%lu\tMP_RECV %lu\tMP_SENT %lu\tS_PARSE %lu\tF_PARSE %lu\tCHKFAIL %lu\tOUT_DROP %lu\tIN_DROP "
+        "%lu\tPOS_PROC %lu\tPWM_WRAPS %lu\tTEMP %.2f",
         (unsigned long)xFreeHeapSpace, (unsigned long)usb_serial_characters_received,
         (unsigned long)usb_serial_messages_received, (unsigned long)usb_serial_messages_sent,
         (unsigned long)uart_characters_received, (unsigned long)uart_messages_received,
         (unsigned long)uart_messages_sent, (unsigned long)message_processor_messages_received,
         (unsigned long)message_processor_messages_sent, (unsigned long)successful_messages_parsed,
-        (unsigned long)failed_messages_parsed, (unsigned long)checksum_errors,
-        (unsigned long)position_messages_processed, (unsigned long)number_of_pwm_wraps, board_temperature);
+        (unsigned long)failed_messages_parsed, (unsigned long)checksum_errors, (unsigned long)outgoing_messages_dropped,
+        (unsigned long)incoming_messages_dropped, (unsigned long)position_messages_processed,
+        (unsigned long)number_of_pwm_wraps, board_temperature);
+
+#if USE_EEPROM
+    // Append the lifetime power-on hours odometer (uptime and motor-powered)
+    {
+        size_t hours_len = strlen(message);
+        snprintf(message + hours_len, USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH - hours_len, "\tUP_HRS %lu\tMTR_HRS %lu",
+                 (unsigned long)eeprom_hours_get_uptime_hours(), (unsigned long)eeprom_hours_get_motor_hours());
+    }
+#endif
 
 #ifdef CC_VER4
     // Append Dynamixel bus metrics if available

--- a/firmware/src/device/eeprom.c
+++ b/firmware/src/device/eeprom.c
@@ -1,16 +1,16 @@
 
 #include <FreeRTOS.h>
+#include <task.h>
+#include <timers.h>
 
 #include "hardware/i2c.h"
 #include "pico/stdlib.h"
 
-
 #include "controller/config.h"
 #include "logging/logging.h"
 
-
 #include "eeprom.h"
-
+#include "eeprom_hours.h"
 
 extern uint16_t usb_pid;
 extern uint16_t usb_vid;
@@ -29,7 +29,6 @@ void dump_hex(const uint8_t *data, size_t len) {
     printf("\n");
 }
 
-
 /**
  * Configure the I2C bus for the EEPROM
  */
@@ -40,13 +39,12 @@ void eeprom_setup_i2c() {
     gpio_set_function(EEPROM_SDA_PIN, GPIO_FUNC_I2C);
     gpio_set_function(EEPROM_SCL_PIN, GPIO_FUNC_I2C);
 
-    i2c_init(EEPROM_I2C_BUS, 100 * 1000);   // Nice and slow at 100kHz
+    i2c_init(EEPROM_I2C_BUS, 100 * 1000); // Nice and slow at 100kHz
 
     gpio_pull_up(EEPROM_SDA_PIN);
     gpio_pull_up(EEPROM_SCL_PIN);
 
     debug("I2C configured at %uHz", 100000);
-
 }
 
 /**
@@ -58,21 +56,19 @@ void read_eeprom_and_configure() {
     u16 data_size = 60;
 
     // Buffer to hold the data
-    u8* eeprom_data = pvPortMalloc(data_size);
+    u8 *eeprom_data = pvPortMalloc(data_size);
     memset(eeprom_data, '\0', data_size);
-
 
     // Read the EEPROM
     eeprom_read(EEPROM_I2C_BUS, EEPROM_I2C_ADDR, 0, eeprom_data, data_size);
 
-    //dump_hex(eeprom_data, data_size);
+    // dump_hex(eeprom_data, data_size);
 
     parse_eeprom_data(eeprom_data, data_size);
 
     //  Release the memory
     vPortFree(eeprom_data);
 }
-
 
 /**
  * Read data from the EEPROM
@@ -85,10 +81,10 @@ void eeprom_read(i2c_inst_t *i2c, u8 eeprom_addr, u16 mem_addr, u8 *data, size_t
 
         // Write the memory address we want to start reading from
         u8 addr_buffer[2] = {(u8)((mem_addr >> 8) & 0xFF), (u8)(mem_addr & 0xFF)};
-        i2c_write_blocking(i2c, eeprom_addr, addr_buffer, 2, true);  // true means keep the bus active
+        i2c_write_blocking(i2c, eeprom_addr, addr_buffer, 2, true); // true means keep the bus active
 
         // Read the data back
-        i2c_read_blocking(i2c, eeprom_addr, data, read_len, false);  // false means release the bus after read
+        i2c_read_blocking(i2c, eeprom_addr, data, read_len, false); // false means release the bus after read
 
         // Move to the next page
         data += read_len;
@@ -96,7 +92,6 @@ void eeprom_read(i2c_inst_t *i2c, u8 eeprom_addr, u16 mem_addr, u8 *data, size_t
         len -= read_len;
     }
 }
-
 
 /**
  * Parse the EEPROM data
@@ -137,7 +132,7 @@ int parse_eeprom_data(const u8 *data, size_t len) {
     configured_logging_level = data[offset++];
 
     // Extract strings using our helper function.
-    if (extract_string(data, len, &offset, usb_serial , sizeof(usb_serial), "serial number") != 0)
+    if (extract_string(data, len, &offset, usb_serial, sizeof(usb_serial), "serial number") != 0)
         return -1;
     if (extract_string(data, len, &offset, usb_product, sizeof(usb_product), "product name") != 0)
         return -1;
@@ -184,9 +179,6 @@ int parse_eeprom_data(const u8 *data, size_t len) {
     return 0;
 }
 
-
-
-
 /**
  * Extract a string from the EEPROM data
  *
@@ -198,8 +190,7 @@ int parse_eeprom_data(const u8 *data, size_t len) {
  * @param fieldName
  * @return
  */
-int extract_string(const u8 *data, size_t len, size_t *offset,
-                   char *buffer, size_t bufsize, const char *fieldName) {
+int extract_string(const u8 *data, size_t len, size_t *offset, char *buffer, size_t bufsize, const char *fieldName) {
     if (*offset >= len) {
         error("No data for %s length!", fieldName);
         return -1;
@@ -215,7 +206,7 @@ int extract_string(const u8 *data, size_t len, size_t *offset,
         return 0;
     }
 
-    (*offset)++;  // Move past the length byte.
+    (*offset)++; // Move past the length byte.
 
     if (*offset + str_len > len) {
         error("Not enough data for %s!", fieldName);
@@ -233,3 +224,178 @@ int extract_string(const u8 *data, size_t len, size_t *offset,
 
     return 0;
 }
+
+/* ------------------------------------------------------------------------- *
+ *  Power-on hours odometer (runtime glue)
+ *
+ *  The pure record logic lives in eeprom_hours.c. This is the part that talks
+ *  to the bus and to FreeRTOS:
+ *
+ *    - eeprom_write()              page-aware EEPROM write
+ *    - eeprom_hours_init()         boot: restore the baseline counters
+ *    - eeprom_hours_start()        start the 15-minute persist timer
+ *    - eeprom_hours_motor_sample() integrate motor-powered time
+ *
+ *  Both the persist timer and the sensor callback that calls
+ *  eeprom_hours_motor_sample() run in the FreeRTOS timer-daemon task, so they
+ *  are mutually serialized - no locks are needed, and the EEPROM stays a
+ *  single-owner bus exactly as the sensor subsystem requires.
+ * ------------------------------------------------------------------------- */
+
+#if USE_EEPROM
+
+/**
+ * Write to the EEPROM, never letting a single page write cross a hardware
+ * page boundary. The chip needs an internal write cycle (~5 ms) before it
+ * accepts the next page, so we wait *between* pages - but never after the
+ * last one. The odometer writes a single 16-byte slot every 15 minutes, so
+ * in practice this never spans a page and never waits at all.
+ */
+void eeprom_write(i2c_inst_t *i2c, u8 eeprom_addr, u16 mem_addr, const u8 *data, size_t len) {
+    while (len > 0) {
+        size_t page_remaining = EEPROM_PAGE_SIZE - (mem_addr % EEPROM_PAGE_SIZE);
+        size_t write_len = len < page_remaining ? len : page_remaining;
+
+        u8 buffer[EEPROM_PAGE_SIZE + 2]; // 2 bytes for the memory address
+        buffer[0] = (u8)((mem_addr >> 8) & 0xFF);
+        buffer[1] = (u8)(mem_addr & 0xFF);
+        memcpy(&buffer[2], data, write_len);
+
+        i2c_write_blocking(i2c, eeprom_addr, buffer, write_len + 2, false);
+
+        data += write_len;
+        mem_addr += write_len;
+        len -= write_len;
+
+        if (len > 0) {
+            vTaskDelay(pdMS_TO_TICKS(EEPROM_WRITE_CYCLE_MS));
+        }
+    }
+}
+
+// Baselines restored from the EEPROM at boot.
+static u32 baseline_uptime_min = 0;
+static u32 baseline_motor_min = 0;
+
+// Ring position of the most recently written (or restored) record.
+static u32 last_seq = 0;
+static u32 last_slot = EEPROM_HOURS_SLOT_COUNT - 1;
+
+// Motor-powered time accumulated since boot, integrated from the sensor loop.
+static u64 motor_on_accum_us = 0;
+static absolute_time_t last_motor_sample;
+static bool motor_sample_primed = false;
+
+static u32 current_uptime_minutes(void) {
+    u64 us = to_us_since_boot(get_absolute_time());
+    return baseline_uptime_min + (u32)(us / 60000000ULL);
+}
+
+static u32 current_motor_minutes(void) { return baseline_motor_min + (u32)(motor_on_accum_us / 60000000ULL); }
+
+void eeprom_hours_init(void) {
+    static u8 region[EEPROM_HOURS_REGION_SIZE];
+
+    eeprom_read(EEPROM_I2C_BUS, EEPROM_I2C_ADDR, EEPROM_HOURS_REGION_ADDR, region, EEPROM_HOURS_REGION_SIZE);
+
+    u32 seq = 0;
+    u32 uptime_min = 0;
+    u32 motor_min = 0;
+    int slot = eeprom_hours_select_slot(region, EEPROM_HOURS_REGION_SIZE, &seq, &uptime_min, &motor_min);
+
+    if (slot < 0) {
+        info("No valid power-on hours record found - starting the odometer at zero");
+        baseline_uptime_min = 0;
+        baseline_motor_min = 0;
+        last_seq = 0;
+        last_slot = EEPROM_HOURS_SLOT_COUNT - 1;
+    } else {
+        baseline_uptime_min = uptime_min;
+        baseline_motor_min = motor_min;
+        last_seq = seq;
+        last_slot = (u32)slot;
+        info("Power-on hours odometer restored: uptime %lu h, motor %lu h (slot %d, seq %lu)",
+             (unsigned long)(uptime_min / 60), (unsigned long)(motor_min / 60), slot, (unsigned long)seq);
+    }
+
+    motor_on_accum_us = 0;
+    motor_sample_primed = false;
+}
+
+static void eeprom_hours_persist(void) {
+    u32 uptime_min = current_uptime_minutes();
+    u32 motor_min = current_motor_minutes();
+    u32 seq = last_seq + 1;
+    u32 slot = (last_slot + 1) % EEPROM_HOURS_SLOT_COUNT;
+
+    u8 record[EEPROM_HOURS_SLOT_SIZE];
+    eeprom_hours_serialize(record, seq, uptime_min, motor_min);
+
+    eeprom_write(EEPROM_I2C_BUS, EEPROM_I2C_ADDR, (u16)(EEPROM_HOURS_REGION_ADDR + slot * EEPROM_HOURS_SLOT_SIZE),
+                 record, EEPROM_HOURS_SLOT_SIZE);
+
+    last_seq = seq;
+    last_slot = slot;
+
+    debug("Persisted odometer: uptime %lu min, motor %lu min (slot %lu, seq %lu)", (unsigned long)uptime_min,
+          (unsigned long)motor_min, (unsigned long)slot, (unsigned long)seq);
+}
+
+static void eeprom_hours_timer_callback(TimerHandle_t xTimer) {
+    (void)xTimer;
+    eeprom_hours_persist();
+}
+
+void eeprom_hours_start(void) {
+    TimerHandle_t timer = xTimerCreate("EepromHoursTimer", pdMS_TO_TICKS(EEPROM_HOURS_PERSIST_INTERVAL_MS),
+                                       pdTRUE,    // Auto-reload
+                                       (void *)0, // Timer ID (unused)
+                                       eeprom_hours_timer_callback);
+
+    if (timer != NULL) {
+        xTimerStart(timer, 0);
+        info("Power-on hours odometer started (persist every %d ms)", EEPROM_HOURS_PERSIST_INTERVAL_MS);
+    } else {
+        error("Failed to create the power-on hours persist timer");
+    }
+}
+
+void eeprom_hours_motor_sample(float motor_voltage) {
+    absolute_time_t now = get_absolute_time();
+
+    if (!motor_sample_primed) {
+        last_motor_sample = now;
+        motor_sample_primed = true;
+        return;
+    }
+
+    int64_t delta_us = absolute_time_diff_us(last_motor_sample, now);
+    last_motor_sample = now;
+
+    if (delta_us > 0 && motor_voltage > MOTOR_POWER_ON_VOLTAGE_THRESHOLD) {
+        motor_on_accum_us += (u64)delta_us;
+    }
+}
+
+u32 eeprom_hours_get_uptime_hours(void) { return current_uptime_minutes() / 60; }
+
+u32 eeprom_hours_get_motor_hours(void) { return current_motor_minutes() / 60; }
+
+#else // !USE_EEPROM
+
+// Stubs so every target that compiles this file links cleanly even when the
+// EEPROM (and therefore the odometer) is disabled.
+void eeprom_write(i2c_inst_t *i2c, u8 eeprom_addr, u16 mem_addr, const u8 *data, size_t len) {
+    (void)i2c;
+    (void)eeprom_addr;
+    (void)mem_addr;
+    (void)data;
+    (void)len;
+}
+void eeprom_hours_init(void) {}
+void eeprom_hours_start(void) {}
+void eeprom_hours_motor_sample(float motor_voltage) { (void)motor_voltage; }
+u32 eeprom_hours_get_uptime_hours(void) { return 0; }
+u32 eeprom_hours_get_motor_hours(void) { return 0; }
+
+#endif // USE_EEPROM

--- a/firmware/src/device/eeprom.h
+++ b/firmware/src/device/eeprom.h
@@ -1,9 +1,9 @@
 
 #pragma once
 
-
 #include "hardware/i2c.h"
 
+#include "eeprom_hours.h"
 #include "types.h"
 
 // The magic string at the top of our binary
@@ -12,8 +12,7 @@
 
 void eeprom_setup_i2c();
 void eeprom_read(i2c_inst_t *i2c, u8 eeprom_addr, u16 mem_addr, u8 *data, size_t len);
+void eeprom_write(i2c_inst_t *i2c, u8 eeprom_addr, u16 mem_addr, const u8 *data, size_t len);
 void read_eeprom_and_configure();
 int parse_eeprom_data(const u8 *data, size_t len);
-int extract_string(const u8 *data, size_t len, size_t *offset,
-                   char *buffer, size_t bufsize, const char *fieldName);
-
+int extract_string(const u8 *data, size_t len, size_t *offset, char *buffer, size_t bufsize, const char *fieldName);

--- a/firmware/src/device/eeprom_hours.c
+++ b/firmware/src/device/eeprom_hours.c
@@ -1,0 +1,110 @@
+
+/**
+ * @file eeprom_hours.c
+ * @brief Pure record logic for the power-on hours odometer.
+ *
+ * No hardware, no FreeRTOS - this is the part that is unit tested on the host.
+ * The runtime glue (EEPROM I/O, the persist timer, motor-voltage integration)
+ * lives in eeprom.c.
+ */
+
+#include <string.h>
+
+#include "controller/config.h"
+
+#include "eeprom_hours.h"
+#include "types.h"
+
+u16 eeprom_hours_crc16(const u8 *data, size_t len) {
+    u16 crc = 0xFFFF;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= (u16)((u16)data[i] << 8);
+        for (int bit = 0; bit < 8; bit++) {
+            crc = (crc & 0x8000) ? (u16)((crc << 1) ^ 0x1021) : (u16)(crc << 1);
+        }
+    }
+    return crc;
+}
+
+static void put_u16(u8 *p, u16 v) {
+    p[0] = (u8)(v >> 8);
+    p[1] = (u8)v;
+}
+
+static void put_u32(u8 *p, u32 v) {
+    p[0] = (u8)(v >> 24);
+    p[1] = (u8)(v >> 16);
+    p[2] = (u8)(v >> 8);
+    p[3] = (u8)v;
+}
+
+static u16 get_u16(const u8 *p) { return (u16)(((u16)p[0] << 8) | p[1]); }
+
+static u32 get_u32(const u8 *p) { return ((u32)p[0] << 24) | ((u32)p[1] << 16) | ((u32)p[2] << 8) | (u32)p[3]; }
+
+void eeprom_hours_serialize(u8 *slot, u32 seq, u32 uptime_min, u32 motor_min) {
+    memset(slot, 0, EEPROM_HOURS_SLOT_SIZE);
+    put_u16(&slot[0], EEPROM_HOURS_MAGIC);
+    put_u32(&slot[2], seq);
+    put_u32(&slot[6], uptime_min);
+    put_u32(&slot[10], motor_min);
+    put_u16(&slot[14], eeprom_hours_crc16(slot, 14));
+}
+
+bool eeprom_hours_deserialize(const u8 *slot, u32 *seq, u32 *uptime_min, u32 *motor_min) {
+    if (get_u16(&slot[0]) != EEPROM_HOURS_MAGIC) {
+        return false;
+    }
+    if (get_u16(&slot[14]) != eeprom_hours_crc16(slot, 14)) {
+        return false;
+    }
+    if (seq != NULL) {
+        *seq = get_u32(&slot[2]);
+    }
+    if (uptime_min != NULL) {
+        *uptime_min = get_u32(&slot[6]);
+    }
+    if (motor_min != NULL) {
+        *motor_min = get_u32(&slot[10]);
+    }
+    return true;
+}
+
+int eeprom_hours_select_slot(const u8 *region, size_t region_len, u32 *seq, u32 *uptime_min, u32 *motor_min) {
+    int best = -1;
+    u32 best_seq = 0;
+
+    size_t count = region_len / EEPROM_HOURS_SLOT_SIZE;
+    if (count > EEPROM_HOURS_SLOT_COUNT) {
+        count = EEPROM_HOURS_SLOT_COUNT;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        const u8 *slot = &region[i * EEPROM_HOURS_SLOT_SIZE];
+        u32 s = 0;
+        u32 u = 0;
+        u32 m = 0;
+
+        if (!eeprom_hours_deserialize(slot, &s, &u, &m)) {
+            continue;
+        }
+
+        // Sequence is monotonic and (at one write per 15 minutes) will not wrap
+        // for ~120,000 years, so a plain max is the newest record.
+        if (best < 0 || s > best_seq) {
+            best = (int)i;
+            best_seq = s;
+            if (seq != NULL) {
+                *seq = s;
+            }
+            if (uptime_min != NULL) {
+                *uptime_min = u;
+            }
+            if (motor_min != NULL) {
+                *motor_min = m;
+            }
+        }
+    }
+
+    return best;
+}

--- a/firmware/src/device/eeprom_hours.h
+++ b/firmware/src/device/eeprom_hours.h
@@ -1,0 +1,69 @@
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "types.h"
+
+/*
+ * Power-on hours odometer.
+ *
+ * Tracks two lifetime counters for a creature and persists them to the I2C
+ * EEPROM: total controller uptime, and the time the motor power rail has been
+ * energized. Storage is a wear-leveled ring of fixed-size records at the top
+ * of the EEPROM (see EEPROM_HOURS_* in config.h).
+ *
+ * On-disk record layout (EEPROM_HOURS_SLOT_SIZE bytes, all big-endian to match
+ * the rest of the EEPROM):
+ *
+ *   offset  size  field
+ *   ------  ----  --------------------------------------------------
+ *      0     2    magic        (EEPROM_HOURS_MAGIC)
+ *      2     4    seq          (monotonic write sequence; highest wins)
+ *      6     4    uptime_min   (total controller uptime, minutes)
+ *     10     4    motor_min    (total motor-powered time, minutes)
+ *     14     2    crc16        (CRC-16/CCITT over bytes 0..13)
+ *
+ * The functions below are pure: no hardware, no FreeRTOS, fully unit-testable
+ * on the host. The runtime glue that talks to the EEPROM and FreeRTOS lives in
+ * eeprom.c.
+ */
+
+/** CRC-16/CCITT-FALSE (poly 0x1021, init 0xFFFF). */
+u16 eeprom_hours_crc16(const u8 *data, size_t len);
+
+/** Serialize a record into a slot buffer of EEPROM_HOURS_SLOT_SIZE bytes. */
+void eeprom_hours_serialize(u8 *slot, u32 seq, u32 uptime_min, u32 motor_min);
+
+/**
+ * Validate and decode a slot. Returns false (and leaves outputs untouched) if
+ * the magic or CRC does not match. Output pointers may be NULL.
+ */
+bool eeprom_hours_deserialize(const u8 *slot, u32 *seq, u32 *uptime_min, u32 *motor_min);
+
+/**
+ * Scan a region buffer and return the index of the newest valid record (the
+ * one with the highest sequence number), or -1 if none is valid (e.g. a blank
+ * 0xFF EEPROM). The newest record's fields are written to the output pointers.
+ */
+int eeprom_hours_select_slot(const u8 *region, size_t region_len, u32 *seq, u32 *uptime_min, u32 *motor_min);
+
+/* -- Runtime odometer (implemented in eeprom.c) -- */
+
+/** Restore the baseline counters from the EEPROM. Call once at boot. */
+void eeprom_hours_init(void);
+
+/** Create and start the periodic persist timer. Call after init. */
+void eeprom_hours_start(void);
+
+/**
+ * Feed the latest motor-power-rail voltage to the odometer. Called from the
+ * i2c sensor read callback every cycle. Cheap and non-blocking: it only
+ * integrates elapsed time, it never touches the bus.
+ */
+void eeprom_hours_motor_sample(float motor_voltage);
+
+/** Current totals in whole hours, for status reporting. */
+u32 eeprom_hours_get_uptime_hours(void);
+u32 eeprom_hours_get_motor_hours(void);

--- a/firmware/src/io/message_processor.c
+++ b/firmware/src/io/message_processor.c
@@ -34,6 +34,17 @@ TaskHandle_t outgoing_message_processor_task_handle;
 volatile u64 message_processor_messages_received = 0L;
 volatile u64 message_processor_messages_sent = 0L;
 
+// Messages dropped because a pipeline queue was full. The USB pipeline never
+// blocks a producer - it drops and counts instead. A non-zero value here means
+// the host isn't draining fast enough, not that the pipeline stalled.
+volatile u64 outgoing_messages_dropped = 0L;
+volatile u64 incoming_messages_dropped = 0L;
+
+// Couple the queue item size to the buffers that feed/drain it, so the two
+// constants can never silently diverge into an over-read/overflow.
+_Static_assert(INCOMING_MESSAGE_MAX_LENGTH == USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH,
+               "incoming queue item size must match the USB serial incoming buffer size");
+
 // USB Serial queue
 extern QueueHandle_t usb_serial_outgoing_messages;
 extern bool outgoing_usb_queue_exists;
@@ -61,7 +72,7 @@ void message_processor_start() {
 
     info("starting the incoming message processor task");
     xTaskCreate(incoming_message_processor_task, "incoming_message_processor_task", configMINIMAL_STACK_SIZE + 1024,
-                NULL, 1, &incoming_message_processor_task_handle);
+                NULL, INCOMING_RX_TASK_PRIORITY, &incoming_message_processor_task_handle);
 
     info("starting the outgoing message processor task");
     xTaskCreate(outgoing_message_processor_task, "outgoing_message_processor_task", configMINIMAL_STACK_SIZE + 1024,
@@ -70,22 +81,41 @@ void message_processor_start() {
 
 bool send_to_controller(const char *message) {
 
-    if (strlen(message) > OUTGOING_MESSAGE_MAX_LENGTH) {
+    const size_t len = strlen(message);
+
+    // Reserve 2 bytes so the '\n' frame + NUL the downstream stages append
+    // always fit inside every fixed-size queue slot and buffer in the pipeline.
+    if (len > OUTGOING_MESSAGE_MAX_LENGTH - 2) {
         // Log directly to stdio to avoid re-entering send_to_controller() via the
         // logging hook, which would create an infinite error cascade since the
         // LOG-wrapped error message would also exceed the max length.
-        printf("[E] not sending message (%u bytes, max %u)\n",
-               (unsigned)strlen(message), (unsigned)OUTGOING_MESSAGE_MAX_LENGTH);
+        printf("[E] not sending message (%u bytes, max %u)\n", (unsigned)len,
+               (unsigned)(OUTGOING_MESSAGE_MAX_LENGTH - 2));
         return false;
     }
 
-    // If the queue isn't full (and it exists), send it
-    if (outgoing_messages && uxQueueSpacesAvailable(outgoing_messages) > 0) {
-        xQueueSendToBack(outgoing_messages, message, (TickType_t)pdMS_TO_TICKS(10));
-        return true;
+    if (outgoing_messages == NULL)
+        return false;
+
+    // Copy into a slot-sized buffer first. The queue item is
+    // OUTGOING_MESSAGE_MAX_LENGTH bytes and xQueueSendToBack copies exactly
+    // that many - reading straight from the caller's (often much smaller)
+    // buffer would over-read it. Callers include the logging hook, whose
+    // buffer is only strlen()+33.
+    char slot[OUTGOING_MESSAGE_MAX_LENGTH];
+    memset(slot, '\0', sizeof(slot));
+    memcpy(slot, message, len);
+
+    // Never block a producer on this queue. A stalled USB pipeline is far
+    // worse than a dropped telemetry/log line - especially since producers
+    // include the timer daemon, whose stall takes the whole system with it.
+    // Enqueue without waiting; drop and count on a full queue.
+    if (xQueueSendToBack(outgoing_messages, slot, 0) != pdTRUE) {
+        outgoing_messages_dropped++;
+        return false;
     }
 
-    return false;
+    return true;
 }
 
 #pragma clang diagnostic push
@@ -176,13 +206,17 @@ portTASK_FUNCTION(outgoing_message_processor_task, pvParameters) {
             strncpy(uart_outgoing_message, rx_buffer, UART_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH);
 #endif
 
-            // Send to the outgoing queue(s)
-            if (is_safe_to_enqueue_outgoing_usb_serial())
-                xQueueSendToBack(usb_serial_outgoing_messages, usb_outgoing_message, (TickType_t)pdMS_TO_TICKS(10));
+            // Hand off to the transport queue(s) without ever blocking. Using
+            // the non-blocking send's return value (instead of a separate
+            // FromISR "is it full?" pre-check, which was both a TOCTOU race and
+            // a FromISR API misused from task context) keeps the pipeline
+            // flowing and makes a full queue a counted drop, not a stall.
+            if (xQueueSendToBack(usb_serial_outgoing_messages, usb_outgoing_message, 0) != pdTRUE)
+                outgoing_messages_dropped++;
 
 #ifdef CC_VER2
-            if (is_safe_to_enqueue_outgoing_uart_serial())
-                xQueueSendToBack(uart_serial_outgoing_messages, uart_outgoing_message, (TickType_t)pdMS_TO_TICKS(10));
+            if (xQueueSendToBack(uart_serial_outgoing_messages, uart_outgoing_message, 0) != pdTRUE)
+                outgoing_messages_dropped++;
 #endif
 
             // Wipe out the buffer for next time

--- a/firmware/src/io/uart_serial.c
+++ b/firmware/src/io/uart_serial.c
@@ -10,11 +10,10 @@
 
 #include "controller/config.h"
 
-#include "logging/logging.h"
 #include "io/uart_serial.h"
+#include "logging/logging.h"
 
 #include "types.h"
-
 
 #ifdef CC_VER2
 
@@ -32,53 +31,42 @@ QueueHandle_t uart_serial_outgoing_messages;
 bool incoming_uart_queue_exists = false;
 bool outgoing_uart_queue_exists = false;
 
-
 // The global incoming messages queue
 extern QueueHandle_t incoming_messages;
 
 void uart_serial_init() {
 
     // Create the incoming queue
-    uart_serial_incoming_commands = xQueueCreate(UART_SERIAL_INCOMING_QUEUE_LENGTH,
-                                                UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
+    uart_serial_incoming_commands =
+        xQueueCreate(UART_SERIAL_INCOMING_QUEUE_LENGTH, UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
     vQueueAddToRegistry(uart_serial_incoming_commands, "uart_incoming_queue");
     incoming_uart_queue_exists = true;
 
     // And the outgoing queue
-    uart_serial_outgoing_messages = xQueueCreate(UART_SERIAL_OUTGOING_QUEUE_LENGTH,
-                                                UART_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH);
+    uart_serial_outgoing_messages =
+        xQueueCreate(UART_SERIAL_OUTGOING_QUEUE_LENGTH, UART_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH);
     vQueueAddToRegistry(uart_serial_outgoing_messages, "uart_outgoing_queue");
     outgoing_uart_queue_exists = true;
 
     info("created the UART serial queues");
 
     // Set up the uart
-    uart_init((uart_inst_t *) UART_DEVICE_NAME, UART_BAUD_RATE);
-    uart_set_format((uart_inst_t *) UART_DEVICE_NAME, 8, 1, UART_PARITY_NONE);
-    uart_set_hw_flow((uart_inst_t *) UART_DEVICE_NAME, false, false);
+    uart_init((uart_inst_t *)UART_DEVICE_NAME, UART_BAUD_RATE);
+    uart_set_format((uart_inst_t *)UART_DEVICE_NAME, 8, 1, UART_PARITY_NONE);
+    uart_set_hw_flow((uart_inst_t *)UART_DEVICE_NAME, false, false);
     gpio_set_function(UART_RX_PIN, GPIO_FUNC_UART);
     gpio_set_function(UART_TX_PIN, GPIO_FUNC_UART);
-
 }
 
 void uart_serial_start() {
 
     info("starting the incoming UART serial reader task");
-    xTaskCreate(incoming_uart_serial_reader_task,
-                "incoming_uart_serial_reader_task",
-                1512,
-                NULL,
-                1,
+    xTaskCreate(incoming_uart_serial_reader_task, "incoming_uart_serial_reader_task", 1512, NULL, 1,
                 &incoming_uart_serial_reader_task_handle);
 
     info("starting the outgoing UART serial writer task");
-    xTaskCreate(outgoing_uart_serial_writer_task,
-                "outgoing_uart_serial_writer_task",
-                1512,
-                NULL,
-                1,
+    xTaskCreate(outgoing_uart_serial_writer_task, "outgoing_uart_serial_writer_task", 1512, NULL, 1,
                 &outgoing_uart_serial_writer_task_handle);
-
 
     // Register the ISR
     irq_set_exclusive_handler(UART1_IRQ, serial_reader_isr);
@@ -86,15 +74,9 @@ void uart_serial_start() {
     uart_set_irq_enables(UART_DEVICE_NAME, true, false);
 }
 
-bool is_safe_to_enqueue_incoming_uart_serial() {
-    return (incoming_uart_queue_exists && !xQueueIsQueueFullFromISR(uart_serial_incoming_commands));
-}
-
-bool is_safe_to_enqueue_outgoing_uart_serial() {
-    return (outgoing_uart_queue_exists && !xQueueIsQueueFullFromISR(uart_serial_outgoing_messages));
-}
-
-
+// (Removed is_safe_to_enqueue_incoming/outgoing_uart_serial: dead code that
+//  also misused xQueueIsQueueFullFromISR from task context. The real UART RX
+//  ISR (serial_reader_isr) below correctly uses xQueueSendToBackFromISR.)
 
 portTASK_FUNCTION(incoming_uart_serial_reader_task, pvParameters) {
 
@@ -103,21 +85,19 @@ portTASK_FUNCTION(incoming_uart_serial_reader_task, pvParameters) {
     // Bad things are gonna happen if this is null
     configASSERT(uart_serial_incoming_commands != NULL);
 
-
     // Define our buffer and zero it out
-    char *rx_buffer = (char *) pvPortMalloc(sizeof(char) * UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
+    char *rx_buffer = (char *)pvPortMalloc(sizeof(char) * UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
     if (rx_buffer == NULL) {
         configASSERT("stopping the UART reader because of a failure to allocate memory");
         return;
     }
     memset(rx_buffer, '\0', UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
 
-
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "EndlessLoop"
     for (EVER) {
 
-        if (xQueueReceive(uart_serial_incoming_commands, rx_buffer, (TickType_t) portMAX_DELAY) == pdPASS) {
+        if (xQueueReceive(uart_serial_incoming_commands, rx_buffer, (TickType_t)portMAX_DELAY) == pdPASS) {
 
             uart_characters_received = uart_characters_received + 1;
 
@@ -129,17 +109,14 @@ portTASK_FUNCTION(incoming_uart_serial_reader_task, pvParameters) {
             strncpy(message, rx_buffer, UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
 
             // Send this off to the incoming messages queue
-            xQueueSendToBack(incoming_messages, &message, (TickType_t) portMAX_DELAY);
+            xQueueSendToBack(incoming_messages, &message, (TickType_t)portMAX_DELAY);
 
             // Wipe out the buffer for next time
             memset(rx_buffer, '\0', UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
-
         }
     }
 #pragma clang diagnostic pop
-
 }
-
 
 portTASK_FUNCTION(outgoing_uart_serial_writer_task, pvParameters) {
 
@@ -149,7 +126,7 @@ portTASK_FUNCTION(outgoing_uart_serial_writer_task, pvParameters) {
     configASSERT(uart_serial_outgoing_messages != NULL);
 
     // Allocate buffer on the heap
-    char *rx_buffer = (char *) pvPortMalloc(UART_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH + 3);
+    char *rx_buffer = (char *)pvPortMalloc(UART_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH + 3);
     if (rx_buffer == NULL) {
         configASSERT("stopping the UART writer because of a failure to allocate memory");
         return;
@@ -168,10 +145,7 @@ portTASK_FUNCTION(outgoing_uart_serial_writer_task, pvParameters) {
             memset(rx_buffer, '\0', UART_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH + 3);
         }
     }
-
 }
-
-
 
 /**
  * Much like the USB serial reader, this is handled in an ISR. It's called when
@@ -181,14 +155,12 @@ void __isr serial_reader_isr() {
     static char lineBuffer[UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH];
     static u32 bufferIndex = 0;
 
-
-
     /*
      * Get all of the data we can in this pass, but remember this is an
      * ISR and we need to be done fast!
      */
-    while(uart_is_readable(UART_DEVICE_NAME)) {
-        u8 ch;  // Temporary buffer to hold incoming data
+    while (uart_is_readable(UART_DEVICE_NAME)) {
+        u8 ch; // Temporary buffer to hold incoming data
 
         ch = uart_getc(UART_DEVICE_NAME);
 
@@ -215,26 +187,25 @@ void __isr serial_reader_isr() {
                 break;
             }
 
-            lineBuffer[bufferIndex] = '\0';  // Null-terminate the string
+            lineBuffer[bufferIndex] = '\0'; // Null-terminate the string
             xQueueSendToBackFromISR(uart_serial_incoming_commands, lineBuffer, NULL);
             uart_messages_received = uart_messages_received + 1;
 
-            bufferIndex = 0;  // Reset buffer index
+            bufferIndex = 0; // Reset buffer index
 
         } else if (bufferIndex < UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH - 1) {
-            lineBuffer[bufferIndex++] = ch;  // Store character and increment index
+            lineBuffer[bufferIndex++] = ch; // Store character and increment index
 
         } else {
             // Buffer overflow handling
-            lineBuffer[UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH - 1] = '\0';  // Ensure null-termination
+            lineBuffer[UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH - 1] = '\0'; // Ensure null-termination
             xQueueSendToBackFromISR(uart_serial_incoming_commands, lineBuffer, NULL);
             uart_messages_received = uart_messages_received + 1;
 
-            bufferIndex = 0;  // Reset buffer index
+            bufferIndex = 0; // Reset buffer index
 
             warning("buffer overflow on incoming data");
         }
-
     }
 
     // Additional safety check for null-termination

--- a/firmware/src/io/uart_serial.h
+++ b/firmware/src/io/uart_serial.h
@@ -4,23 +4,17 @@
 #include <FreeRTOS.h>
 #include <task.h>
 
-
 #include "message_processor.h"
 
 #include "logging/logging.h"
 
-
 #include "controller/config.h"
-
 
 // There's no UART on versions 3 and up
 #ifdef CC_VER2
 
 void uart_serial_init();
 void uart_serial_start();
-
-bool is_safe_to_enqueue_incoming_uart_serial();
-bool is_safe_to_enqueue_outgoing_uart_serial();
 
 void __isr serial_reader_isr();
 

--- a/firmware/src/io/usb_serial.c
+++ b/firmware/src/io/usb_serial.c
@@ -7,18 +7,20 @@
 
 #include "controller/config.h"
 
-#include "logging/logging.h"
 #include "io/usb_serial.h"
+#include "logging/logging.h"
 #include "usb/usb.h"
 
 #include "types.h"
 
-
 // Stats (from the status_lights module)
 extern volatile u64 usb_serial_characters_received;
 
+// From message_processor.c - the inbound pipeline never blocks; it drops and
+// counts. tud_cdc_rx_cb feeds the first queue in that pipeline.
+extern volatile u64 incoming_messages_dropped;
+
 TaskHandle_t incoming_usb_serial_reader_task_handle;
-TaskHandle_t outgoing_usb_serial_writer_task_handle;
 
 QueueHandle_t usb_serial_incoming_commands;
 QueueHandle_t usb_serial_outgoing_messages;
@@ -29,49 +31,34 @@ bool outgoing_usb_queue_exists = false;
 void usb_serial_init() {
 
     // Create the incoming queue
-    usb_serial_incoming_commands = xQueueCreate(USB_SERIAL_INCOMING_QUEUE_LENGTH,
-                                                USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
+    usb_serial_incoming_commands =
+        xQueueCreate(USB_SERIAL_INCOMING_QUEUE_LENGTH, USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
     vQueueAddToRegistry(usb_serial_incoming_commands, "usb_incoming_queue");
     incoming_usb_queue_exists = true;
 
     // And the outgoing queue
-    usb_serial_outgoing_messages = xQueueCreate(USB_SERIAL_OUTGOING_QUEUE_LENGTH,
-                                                USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH);
+    usb_serial_outgoing_messages =
+        xQueueCreate(USB_SERIAL_OUTGOING_QUEUE_LENGTH, USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH);
     vQueueAddToRegistry(usb_serial_outgoing_messages, "usb_outgoing_queue");
     outgoing_usb_queue_exists = true;
 
     info("created the USB serial queues");
-
 }
 
 void usb_serial_start() {
 
     info("starting the incoming USB serial reader task");
-    xTaskCreate(incoming_usb_serial_reader_task,
-                "incoming_usb_serial_reader_task",
-                1512,
-                NULL,
-                1,
-                &incoming_usb_serial_reader_task_handle);
+    xTaskCreate(incoming_usb_serial_reader_task, "incoming_usb_serial_reader_task", 1512, NULL,
+                INCOMING_RX_TASK_PRIORITY, &incoming_usb_serial_reader_task_handle);
 
-    info("starting the outgoing USB serial writer task");
-    xTaskCreate(outgoing_usb_serial_writer_task,
-                "outgoing_usb_serial_writer_task",
-                1512,
-                NULL,
-                1,
-                &outgoing_usb_serial_writer_task_handle);
-
+    // The outbound side is handled by usb_device_task (see usb.c): TinyUSB
+    // OPT_OS_NONE requires a single context for tud_task() + CDC writes, so
+    // there is no separate writer task anymore.
 }
 
-bool is_safe_to_enqueue_incoming_usb_serial() {
-    return (incoming_usb_queue_exists && !xQueueIsQueueFullFromISR(usb_serial_incoming_commands));
-}
-
-bool is_safe_to_enqueue_outgoing_usb_serial() {
-    return (outgoing_usb_queue_exists && !xQueueIsQueueFullFromISR(usb_serial_outgoing_messages));
-}
-
+// (Removed is_safe_to_enqueue_incoming/outgoing_usb_serial: dead code that
+//  also misused xQueueIsQueueFullFromISR from task context. The pipeline now
+//  uses non-blocking sends and acts on their return value instead.)
 
 /**
  * Invoked from TUSB when there's data to be read
@@ -84,12 +71,14 @@ void tud_cdc_rx_cb(uint8_t itf) {
     static char lineBuffer[USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH];
     static u32 bufferIndex = 0;
 
-    // Check how many bytes are available
-    u32 count = tud_cdc_available();
+    // Drain the CDC RX FIFO in fixed-size chunks. This callback runs inside
+    // tud_task() on the timer-daemon stack, so a FIFO-sized VLA here (the RX
+    // FIFO is CFG_TUD_CDC_RX_BUFSIZE = 8 KB) would overflow that stack. A
+    // bounded buffer + loop drains everything with no unbounded stack use.
+    u8 tempBuffer[USB_SERIAL_RX_CHUNK];
+    u32 readCount;
 
-    if (count > 0) {
-        u8 tempBuffer[count];  // Temporary buffer to hold incoming data
-        u32 readCount = tud_cdc_read(tempBuffer, count);
+    while ((readCount = tud_cdc_read(tempBuffer, sizeof(tempBuffer))) > 0) {
 
         for (u32 i = 0; i < readCount; ++i) {
             char ch = tempBuffer[i];
@@ -112,7 +101,7 @@ void tud_cdc_rx_cb(uint8_t itf) {
             if (ch == 0x07) {
 
                 // We heard a bell! Time to reset everything!
-                memset(lineBuffer, '\0', UART_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
+                memset(lineBuffer, '\0', sizeof(lineBuffer));
                 bufferIndex = 0;
 
                 // Let the user know, if the logger is up and running! 😅
@@ -125,29 +114,37 @@ void tud_cdc_rx_cb(uint8_t itf) {
 
                 verbose("it's the blessed character");
 
-                // If there was a blank line warn the sender
+                // If there was a blank line warn the sender. Use continue, not
+                // break: break would discard every byte already read after
+                // this point in the chunk (those bytes are gone from the FIFO),
+                // silently dropping any commands that followed the blank line.
                 if (bufferIndex == 0) {
                     warning("skipping blank input line from sender");
-                    break;
+                    continue;
                 }
 
-                lineBuffer[bufferIndex] = '\0';  // Null-terminate the string
+                lineBuffer[bufferIndex] = '\0'; // Null-terminate the string
 
-                verbose("queue length: %u", uxQueueMessagesWaitingFromISR(usb_serial_incoming_commands));
-                xQueueSendToBackFromISR(usb_serial_incoming_commands, lineBuffer, NULL);
-                verbose("queue length: %u", uxQueueMessagesWaitingFromISR(usb_serial_incoming_commands));
+                verbose("queue length: %u", uxQueueMessagesWaiting(usb_serial_incoming_commands));
+                // tud_cdc_rx_cb runs inside tud_task() (the timer-daemon task),
+                // never an ISR - so use the task API, and never block: drop and
+                // count if the command queue is full.
+                if (xQueueSendToBack(usb_serial_incoming_commands, lineBuffer, 0) != pdTRUE)
+                    incoming_messages_dropped++;
+                verbose("queue length: %u", uxQueueMessagesWaiting(usb_serial_incoming_commands));
 
-                bufferIndex = 0;  // Reset buffer index
+                bufferIndex = 0; // Reset buffer index
 
             } else if (bufferIndex < USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH - 1) {
-                lineBuffer[bufferIndex++] = ch;  // Store character and increment index
+                lineBuffer[bufferIndex++] = ch; // Store character and increment index
 
             } else {
                 // Buffer overflow handling
-                lineBuffer[USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH - 1] = '\0';  // Ensure null-termination
-                xQueueSendToBackFromISR(usb_serial_incoming_commands, lineBuffer, NULL);
+                lineBuffer[USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH - 1] = '\0'; // Ensure null-termination
+                if (xQueueSendToBack(usb_serial_incoming_commands, lineBuffer, 0) != pdTRUE)
+                    incoming_messages_dropped++;
 
-                bufferIndex = 0;  // Reset buffer index
+                bufferIndex = 0; // Reset buffer index
 
                 warning("buffer overflow on incoming data");
             }

--- a/firmware/src/io/usb_serial.h
+++ b/firmware/src/io/usb_serial.h
@@ -8,12 +8,7 @@
 
 #include "types.h"
 
-
 void usb_serial_init();
 void usb_serial_start();
 
-bool is_safe_to_enqueue_incoming_usb_serial();
-bool is_safe_to_enqueue_outgoing_usb_serial();
-
 portTASK_FUNCTION_PROTO(incoming_usb_serial_reader_task, pvParameters);
-portTASK_FUNCTION_PROTO(outgoing_usb_serial_writer_task, pvParameters);

--- a/firmware/src/io/usb_workers.c
+++ b/firmware/src/io/usb_workers.c
@@ -6,21 +6,22 @@
 
 #include "controller/config.h"
 
-#include "pico/stdlib.h"
 #include "pico/stdio.h"
+#include "pico/stdlib.h"
 
-#include "logging/logging.h"
 #include "io/usb_serial.h"
+#include "logging/logging.h"
 #include "usb/usb.h"
 
 #include "types.h"
 
 extern volatile u64 usb_serial_messages_received;
-extern volatile u64 usb_serial_messages_sent;
 
-// Our queues
+// From message_processor.c - pipeline never blocks, it drops and counts.
+extern volatile u64 incoming_messages_dropped;
+
+// Our queue (inbound only; the outbound side is owned by usb_device_task)
 extern QueueHandle_t usb_serial_incoming_commands;
-extern QueueHandle_t usb_serial_outgoing_messages;
 
 // The global incoming messages queue
 extern QueueHandle_t incoming_messages;
@@ -32,23 +33,21 @@ portTASK_FUNCTION(incoming_usb_serial_reader_task, pvParameters) {
     // Bad things are gonna happen if this is null
     configASSERT(usb_serial_incoming_commands != NULL);
 
-    //gpio_init(CDC_ACTIVE_PIN);
-    //gpio_set_dir(CDC_ACTIVE_PIN, GPIO_OUT);
+    // gpio_init(CDC_ACTIVE_PIN);
+    // gpio_set_dir(CDC_ACTIVE_PIN, GPIO_OUT);
     bool isOn = true;
     uint8_t direction = 1;
     uint64_t count = 0L;
 
-
     // Define our buffer and zero it out
-    char *rx_buffer = (char *) pvPortMalloc(sizeof(char) * USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
+    char *rx_buffer = (char *)pvPortMalloc(sizeof(char) * USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
     memset(rx_buffer, '\0', USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
-
 
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "EndlessLoop"
     for (EVER) {
 
-        if (xQueueReceive(usb_serial_incoming_commands, rx_buffer, (TickType_t) portMAX_DELAY) == pdPASS) {
+        if (xQueueReceive(usb_serial_incoming_commands, rx_buffer, (TickType_t)portMAX_DELAY) == pdPASS) {
 
             usb_serial_messages_received = usb_serial_messages_received + 1;
 
@@ -59,8 +58,11 @@ portTASK_FUNCTION(incoming_usb_serial_reader_task, pvParameters) {
             // Copy the message into the buffer
             strncpy(message, rx_buffer, USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
 
-            // Send this off to the incoming messages queue
-            xQueueSendToBack(incoming_messages, &message, (TickType_t) portMAX_DELAY);
+            // Send this off to the incoming messages queue. Never block here:
+            // a wedged consumer must not back up and stall the USB reader (and
+            // through it, tud_task). Drop and count if the queue is full.
+            if (xQueueSendToBack(incoming_messages, &message, 0) != pdTRUE)
+                incoming_messages_dropped++;
 
             // Wipe out the buffer for next time
             memset(rx_buffer, '\0', USB_SERIAL_INCOMING_MESSAGE_MAX_LENGTH);
@@ -71,41 +73,14 @@ portTASK_FUNCTION(incoming_usb_serial_reader_task, pvParameters) {
             } else {
                 direction = 0;
             }
-            //gpio_put(CDC_ACTIVE_PIN, direction);
+            // gpio_put(CDC_ACTIVE_PIN, direction);
             isOn = !isOn;
         }
     }
 #pragma clang diagnostic pop
-
 }
 
-
-portTASK_FUNCTION(outgoing_usb_serial_writer_task, pvParameters) {
-
-    debug("hello from the serial writer!");
-
-    // Bad things are gonna happen if this is null, too! 😱
-    configASSERT(usb_serial_outgoing_messages != NULL);
-
-    // Allocate buffer on the heap
-    char *rx_buffer = (char *) pvPortMalloc(USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH + 3);
-    if (rx_buffer == NULL) {
-        configASSERT("stopping the serial writer because of a failure to allocate memory");
-        return;
-    }
-
-    memset(rx_buffer, '\0', USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH + 2);
-
-    for (EVER) {
-
-        // Make sure that we aren't writing anything bigger than this on the other side!
-        if (xQueueReceive(usb_serial_outgoing_messages, rx_buffer, portMAX_DELAY) == pdPASS) {
-
-            usb_serial_messages_sent = usb_serial_messages_sent + 1;
-            cdc_send(rx_buffer);
-
-            memset(rx_buffer, '\0', USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH + 3);
-        }
-    }
-
-}
+// The outbound writer task lived here. It now lives in usb_device_task
+// (src/usb/usb.c): TinyUSB is OPT_OS_NONE, so tud_task() and all CDC writes
+// must run in one context. The USB task drains usb_serial_outgoing_messages
+// directly.

--- a/firmware/src/logging/logging.c
+++ b/firmware/src/logging/logging.c
@@ -1,11 +1,11 @@
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
-#include <stdarg.h>
 #include <string.h>
 
+#include "pico/time.h"
 #include <FreeRTOS.h>
 #include <queue.h>
-#include "pico/time.h"
 
 #include "logging.h"
 #include "logging_api.h"
@@ -13,14 +13,12 @@
 #include "controller/config.h"
 #include "types.h"
 
-
 TaskHandle_t log_queue_reader_task_handle;
 QueueHandle_t creature_log_message_queue_handle;
 bool volatile logging_queue_exists = false;
 
 // What level of logging we want (this is overridden from the EEPROM if it exists)
 u8 configured_logging_level = DEFAULT_LOGGING_LEVEL;
-
 
 void logger_init() {
     creature_log_message_queue_handle = xQueueCreate(LOGGING_QUEUE_LENGTH, sizeof(struct LogMessage));
@@ -30,7 +28,18 @@ void logger_init() {
 }
 
 bool inline is_safe_to_log() {
-    return (logging_queue_exists && !xQueueIsQueueFullFromISR(creature_log_message_queue_handle));
+    if (!logging_queue_exists)
+        return false;
+
+    // Logging is reached from both task context and real ISRs (e.g. the
+    // CC_VER2 UART RX ISR), so the "is there room?" probe must use the API
+    // that matches the current context - the FromISR variant is only valid
+    // inside an ISR. This preserves the "don't bother formatting if the queue
+    // is full" early-out without misusing a FromISR call from a task.
+    if (portCHECK_IF_IN_ISR())
+        return !xQueueIsQueueFullFromISR(creature_log_message_queue_handle);
+
+    return uxQueueSpacesAvailable(creature_log_message_queue_handle) > 0;
 }
 
 /**
@@ -46,7 +55,18 @@ static void log_internal(uint8_t level, const char *message, va_list args) {
         return;
 
     struct LogMessage lm = createMessageObject(level, message, args);
-    xQueueSendToBackFromISR(creature_log_message_queue_handle, &lm, NULL);
+
+    // Dispatch on the actual calling context. Logging must work from real
+    // ISRs (the CC_VER2 UART RX ISR logs) and from tasks, and must never
+    // block either - so the queue is always sent to without waiting, and a
+    // full queue simply drops the line.
+    if (portCHECK_IF_IN_ISR()) {
+        BaseType_t higher_priority_task_woken = pdFALSE;
+        (void)xQueueSendToBackFromISR(creature_log_message_queue_handle, &lm, &higher_priority_task_woken);
+        portYIELD_FROM_ISR(higher_priority_task_woken);
+    } else {
+        (void)xQueueSendToBack(creature_log_message_queue_handle, &lm, 0);
+    }
 }
 
 void __unused verbose(const char *message, ...) {
@@ -104,30 +124,25 @@ struct LogMessage createMessageObject(uint8_t level, const char *message, va_lis
 }
 
 void start_log_reader() {
-    xTaskCreate(log_queue_reader_task,
-                "log_queue_reader_task",
-                1512,
-                NULL,
-                1,
-                &log_queue_reader_task_handle);
+    xTaskCreate(log_queue_reader_task, "log_queue_reader_task", 1512, NULL, 1, &log_queue_reader_task_handle);
 }
 
-char* log_level_to_string(u8 level) {
+char *log_level_to_string(u8 level) {
     switch (level) {
-        case LOG_LEVEL_VERBOSE:
-            return "Verbose";
-        case LOG_LEVEL_DEBUG:
-            return "Debug";
-        case LOG_LEVEL_INFO:
-            return "Info";
-        case LOG_LEVEL_WARNING:
-            return "Warning";
-        case LOG_LEVEL_ERROR:
-            return "Error";
-        case LOG_LEVEL_FATAL:
-            return "Fatal";
-        default:
-            return "Unknown";
+    case LOG_LEVEL_VERBOSE:
+        return "Verbose";
+    case LOG_LEVEL_DEBUG:
+        return "Debug";
+    case LOG_LEVEL_INFO:
+        return "Info";
+    case LOG_LEVEL_WARNING:
+        return "Warning";
+    case LOG_LEVEL_ERROR:
+        return "Error";
+    case LOG_LEVEL_FATAL:
+        return "Fatal";
+    default:
+        return "Unknown";
     }
 }
 
@@ -147,35 +162,35 @@ portTASK_FUNCTION(log_queue_reader_task, pvParameters) {
     memset(&levelBuffer, '\0', 4);
 
     for (EVER) {
-        if (xQueueReceive(creature_log_message_queue_handle, &lm, (TickType_t) portMAX_DELAY) == pdPASS) {
+        if (xQueueReceive(creature_log_message_queue_handle, &lm, (TickType_t)portMAX_DELAY) == pdPASS) {
             switch (lm.level) {
-                case LOG_LEVEL_VERBOSE:
-                    strncpy(levelBuffer, "[V] ", 3);
-                    break;
-                case LOG_LEVEL_DEBUG:
-                    strncpy(levelBuffer, "[D] ", 3);
-                    break;
-                case LOG_LEVEL_INFO:
-                    strncpy(levelBuffer, "[I] ", 3);
-                    break;
-                case LOG_LEVEL_WARNING:
-                    strncpy(levelBuffer, "[W] ", 3);
-                    break;
-                case LOG_LEVEL_ERROR:
-                    strncpy(levelBuffer, "[E] ", 3);
-                    break;
-                case LOG_LEVEL_FATAL:
-                    strncpy(levelBuffer, "[F] ", 3);
-                    break;
-                default:
-                    strncpy(levelBuffer, "[?] ", 3);
+            case LOG_LEVEL_VERBOSE:
+                strncpy(levelBuffer, "[V] ", 3);
+                break;
+            case LOG_LEVEL_DEBUG:
+                strncpy(levelBuffer, "[D] ", 3);
+                break;
+            case LOG_LEVEL_INFO:
+                strncpy(levelBuffer, "[I] ", 3);
+                break;
+            case LOG_LEVEL_WARNING:
+                strncpy(levelBuffer, "[W] ", 3);
+                break;
+            case LOG_LEVEL_ERROR:
+                strncpy(levelBuffer, "[E] ", 3);
+                break;
+            case LOG_LEVEL_FATAL:
+                strncpy(levelBuffer, "[F] ", 3);
+                break;
+            default:
+                strncpy(levelBuffer, "[?] ", 3);
             }
 
             // Format our messaging
             u32 time = to_ms_since_boot(get_absolute_time());
 
             // Create space on the heap for the message
-            char *message = (char *) pvPortMalloc(strlen(lm.message) + 33);
+            char *message = (char *)pvPortMalloc(strlen(lm.message) + 33);
             memset(message, '\0', strlen(lm.message) + 33);
             snprintf(message, strlen(lm.message) + 32, "LOG\t%lu\t%s\t%s", time, levelBuffer, lm.message);
 

--- a/firmware/src/programmer/i2c_programmer.c
+++ b/firmware/src/programmer/i2c_programmer.c
@@ -4,10 +4,9 @@
 #include <FreeRTOS.h>
 #include <task.h>
 
-#include "pico/stdlib.h"
-#include "pico/stdio.h"
 #include "hardware/i2c.h"
-
+#include "pico/stdio.h"
+#include "pico/stdlib.h"
 
 #include "logging/logging.h"
 
@@ -21,13 +20,12 @@ TaskHandle_t programming_task_handle;
 // Define the EEPROM page size (check the EEPROM's datasheet)
 #define EEPROM_PAGE_SIZE 64
 
-extern u8* incoming_data_buffer;
+extern u8 *incoming_data_buffer;
 extern u32 incomingBufferIndex;
 
 // What state are we in?
 extern enum ProgrammerState programmer_state;
 extern u32 program_size;
-
 
 void programmer_setup_i2c() {
 
@@ -36,26 +34,35 @@ void programmer_setup_i2c() {
     gpio_set_function(PROGRAMMER_SDA_PIN, GPIO_FUNC_I2C);
     gpio_set_function(PROGRAMMER_SCL_PIN, GPIO_FUNC_I2C);
 
-    i2c_init(PROGRAMMER_I2C_BUS, 100 * 1000);   // Nice and slow at 100kHz
+    i2c_init(PROGRAMMER_I2C_BUS, 100 * 1000); // Nice and slow at 100kHz
 
     gpio_pull_up(PROGRAMMER_SDA_PIN);
     gpio_pull_up(PROGRAMMER_SCL_PIN);
 
     debug("I2C configured at %uHz", 100000);
-
 }
 
-void write_incoming_buffer_to_eeprom() {
+bool write_incoming_buffer_to_eeprom() {
 
     info("Programming I2C EEPROM");
     debug("There are %u bytes to program", program_size);
+
+    // The top of the EEPROM is reserved for the controller's power-on hours
+    // odometer. A personality image is only a few dozen bytes, so this should
+    // never trip - but refuse rather than silently clobber the odometer.
+    if (program_size > EEPROM_HOURS_REGION_ADDR) {
+        error("Refusing to burn: image (%u bytes) would overwrite the reserved "
+              "power-on hours region at 0x%04X",
+              program_size, EEPROM_HOURS_REGION_ADDR);
+        return false;
+    }
 
     // Write the full flash array to the EEPROM
     i2c_eeprom_write(PROGRAMMER_I2C_BUS, PROGRAMMER_I2C_ADDR, 0, incoming_data_buffer, program_size);
     info("I2C EEPROM programmed");
 
+    return true;
 }
-
 
 void i2c_eeprom_write(i2c_inst_t *i2c, uint8_t eeprom_addr, uint16_t mem_addr, const u8 *data, size_t len) {
 
@@ -69,8 +76,8 @@ void i2c_eeprom_write(i2c_inst_t *i2c, uint8_t eeprom_addr, uint16_t mem_addr, c
         total_bytes_written += write_len;
 
         uint8_t buffer[EEPROM_PAGE_SIZE + 2]; // 2 bytes for memory address
-        buffer[0] = (mem_addr >> 8) & 0xFF;  // High byte of memory address
-        buffer[1] = mem_addr & 0xFF;         // Low byte of memory address
+        buffer[0] = (mem_addr >> 8) & 0xFF;   // High byte of memory address
+        buffer[1] = mem_addr & 0xFF;          // Low byte of memory address
 
         // Copy data to buffer
         for (size_t i = 0; i < write_len; ++i) {
@@ -87,21 +94,19 @@ void i2c_eeprom_write(i2c_inst_t *i2c, uint8_t eeprom_addr, uint16_t mem_addr, c
         mem_addr += write_len;
         len -= write_len;
 
-        if(total_bytes_written % 2048 == 0) {
+        if (total_bytes_written % 2048 == 0) {
             debug("Wrote %u bytes to EEPROM", total_bytes_written);
         }
-
 
         // Wait for the EEPROM to complete the write cycle (typically ~5ms, but let's go slow)
         vTaskDelay(pdMS_TO_TICKS(15));
     }
 }
 
-
 void print_eeprom_contents(const u8 *data, size_t len) {
 
     // Make sure we're not trying to print nothing
-    if(data == NULL || len == 0) {
+    if (data == NULL || len == 0) {
         warning("No data to print");
         return;
     }
@@ -121,7 +126,6 @@ void print_eeprom_contents(const u8 *data, size_t len) {
         // Append the next byte to the current line, checking buffer space
         snprintf(line_buffer + strlen(line_buffer), sizeof(line_buffer) - strlen(line_buffer), "%02X ", data[i]);
 
-
         // If 32 bytes have been added, or it's the end of the data, print the line
         if (i % 32 == 31 || i == len - 1) {
             verbose(line_buffer);
@@ -134,7 +138,6 @@ void print_eeprom_contents(const u8 *data, size_t len) {
     verbose("--- End of EEPROM data ---");
 }
 
-
 void i2c_eeprom_read(i2c_inst_t *i2c, uint8_t eeprom_addr, uint16_t mem_addr, uint8_t *data, size_t len) {
     while (len > 0) {
         size_t read_len = len > EEPROM_PAGE_SIZE ? EEPROM_PAGE_SIZE : len;
@@ -143,10 +146,10 @@ void i2c_eeprom_read(i2c_inst_t *i2c, uint8_t eeprom_addr, uint16_t mem_addr, ui
 
         // Write the memory address we want to start reading from
         uint8_t addr_buffer[2] = {(uint8_t)((mem_addr >> 8) & 0xFF), (uint8_t)(mem_addr & 0xFF)};
-        i2c_write_blocking(i2c, eeprom_addr, addr_buffer, 2, true);  // true means keep the bus active
+        i2c_write_blocking(i2c, eeprom_addr, addr_buffer, 2, true); // true means keep the bus active
 
         // Read the data back
-        i2c_read_blocking(i2c, eeprom_addr, data, read_len, false);  // false means release the bus after read
+        i2c_read_blocking(i2c, eeprom_addr, data, read_len, false); // false means release the bus after read
 
         // Move to the next page
         data += read_len;
@@ -155,7 +158,8 @@ void i2c_eeprom_read(i2c_inst_t *i2c, uint8_t eeprom_addr, uint16_t mem_addr, ui
     }
 }
 
-bool verify_eeprom_data(i2c_inst_t *i2c, uint8_t eeprom_addr, const u8 *expected_data, size_t len, char* result, size_t result_len) {
+bool verify_eeprom_data(i2c_inst_t *i2c, uint8_t eeprom_addr, const u8 *expected_data, size_t len, char *result,
+                        size_t result_len) {
 
     debug("Verifying EEPROM data, length: %u", len);
 
@@ -165,10 +169,9 @@ bool verify_eeprom_data(i2c_inst_t *i2c, uint8_t eeprom_addr, const u8 *expected
     // Allocate a buffer to read the data back
     debug("Allocating memory for read buffer");
     vTaskDelay(pdMS_TO_TICKS(10));
-    u8* read_data = (u8*)pvPortMalloc(len);    // An assert will be thrown if this fails
+    u8 *read_data = (u8 *)pvPortMalloc(len); // An assert will be thrown if this fails
 
-
-    if(read_data == NULL) {
+    if (read_data == NULL) {
         error("Failed to allocate memory for read buffer");
         snprintf(result, result_len, "ERR Failed to allocate memory for read buffer");
         goto end;
@@ -193,7 +196,8 @@ bool verify_eeprom_data(i2c_inst_t *i2c, uint8_t eeprom_addr, const u8 *expected
 
         if (read_data[i] != (uint8_t)expected_data[i]) {
 
-            snprintf(result, result_len, "ERR Mismatch at byte %zu: expected 0x%02X, got 0x%02X", i, (uint8_t)expected_data[i], read_data[i]);
+            snprintf(result, result_len, "ERR Mismatch at byte %zu: expected 0x%02X, got 0x%02X", i,
+                     (uint8_t)expected_data[i], read_data[i]);
             warning("Mismatch at byte %zu: expected 0x%02X, got 0x%02X", i, (uint8_t)expected_data[i], read_data[i]);
             returnVal = false;
             goto end;
@@ -206,11 +210,10 @@ bool verify_eeprom_data(i2c_inst_t *i2c, uint8_t eeprom_addr, const u8 *expected
     returnVal = true;
     goto end;
 
-
-    end:
+end:
 
     // Release the buffer
-    if(read_data != NULL) {
+    if (read_data != NULL) {
         vPortFree(read_data);
     }
     return returnVal;

--- a/firmware/src/programmer/i2c_programmer.h
+++ b/firmware/src/programmer/i2c_programmer.h
@@ -11,13 +11,12 @@
 
 #define PROGRAMMER_I2C_ADDR 0x50
 
-
 void programmer_setup_i2c();
 void programmer_program_i2c();
-
 
 void i2c_eeprom_write(i2c_inst_t *i2c, uint8_t eeprom_addr, uint16_t mem_addr, const u8 *data, size_t len);
 void print_eeprom_contents(const u8 *data, size_t len);
 void i2c_eeprom_read(i2c_inst_t *i2c, uint8_t eeprom_addr, uint16_t mem_addr, u8 *data, size_t len);
-bool verify_eeprom_data(i2c_inst_t *i2c, uint8_t eeprom_addr, const u8 *expected_data, size_t len, char* result, size_t result_len);
-void write_incoming_buffer_to_eeprom();
+bool verify_eeprom_data(i2c_inst_t *i2c, uint8_t eeprom_addr, const u8 *expected_data, size_t len, char *result,
+                        size_t result_len);
+bool write_incoming_buffer_to_eeprom();

--- a/firmware/src/programmer/shell.c
+++ b/firmware/src/programmer/shell.c
@@ -1,10 +1,10 @@
 
 #include <ctype.h>
+#include <errno.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include <errno.h>
 
 #include <FreeRTOS.h>
 #include <task.h>
@@ -28,17 +28,14 @@ TaskHandle_t shell_task_handle = NULL;
 
 extern volatile size_t xFreeHeapSpace;
 
-extern u8* incoming_data_buffer;
+extern u8 *incoming_data_buffer;
 extern u32 incomingBufferIndex;
 
-extern u8* request_buffer;
+extern u8 *request_buffer;
 extern u32 requestBufferIndex;
 
 extern enum ProgrammerState programmer_state;
 extern u32 program_size;
-
-
-
 
 void handle_shell_command(u8 *buffer) {
 
@@ -48,208 +45,209 @@ void handle_shell_command(u8 *buffer) {
 
     switch (command) {
 
-        case 'B':
-            info("burning the EEPROM...");
+    case 'B':
+        info("burning the EEPROM...");
 
-            if(program_size == 0) {
-                warning("No data to burn!");
-                send_response("ERR No data to burn!");
-                reset_request_buffer();
-                break;
-            }
+        if (program_size == 0) {
+            warning("No data to burn!");
+            send_response("ERR No data to burn!");
+            reset_request_buffer();
+            break;
+        }
 
-            write_incoming_buffer_to_eeprom();
+        if (write_incoming_buffer_to_eeprom()) {
             send_response("OK");
+        } else {
+            send_response("ERR Image would overwrite reserved hours region");
+        }
+        reset_request_buffer();
+        break;
+
+    case 'V':
+        info("verifying the EEPROM...");
+
+        if (program_size == 0) {
+            warning("No data to verify!");
+            send_response("ERR No data to verify!");
             reset_request_buffer();
             break;
+        }
 
-        case 'V':
-            info("verifying the EEPROM...");
+        char result[100];
 
-            if(program_size == 0) {
-                warning("No data to verify!");
-                send_response("ERR No data to verify!");
-                reset_request_buffer();
-                break;
-            }
+        verify_eeprom_data(PROGRAMMER_I2C_BUS, PROGRAMMER_I2C_ADDR, incoming_data_buffer, program_size, result,
+                           sizeof(result));
+        reset_request_buffer();
+        send_response(result);
+        break;
 
-            char result[100];
+    case 'H':
+        info("help command");
+        const char *help_text0 =
+            "\nI - Info in machine-readable format\nB - Burn\nV - Verify\nP - Print incoming data buffer";
+        const char *help_text1 = "R - Reboot\nL##### - Load # bytes\n<ESC> - Reset Request Buffer\nH - Help";
+        send_response(help_text0);
+        send_response(help_text1);
 
-            verify_eeprom_data(PROGRAMMER_I2C_BUS, PROGRAMMER_I2C_ADDR, incoming_data_buffer, program_size,
-                                result, sizeof(result));
-            reset_request_buffer();
-            send_response(result);
-            break;
+        char help_buffer[OUTGOING_RESPONSE_BUFFER_SIZE];
 
-        case 'H':
-            info("help command");
-            const char *help_text0 = "\nI - Info in machine-readable format\nB - Burn\nV - Verify\nP - Print incoming data buffer";
-            const char *help_text1 = "R - Reboot\nL##### - Load # bytes\n<ESC> - Reset Request Buffer\nH - Help";
-            send_response(help_text0);
-            send_response(help_text1);
+        memset(help_buffer, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
+        snprintf(help_buffer, OUTGOING_RESPONSE_BUFFER_SIZE, "\nFree heap: %u bytes\n", xFreeHeapSpace);
+        send_response(help_buffer);
 
-            char help_buffer[OUTGOING_RESPONSE_BUFFER_SIZE];
+        memset(help_buffer, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
+        snprintf(help_buffer, OUTGOING_RESPONSE_BUFFER_SIZE, "This is version %s.\n", CREATURE_FIRMWARE_VERSION_STRING);
+        send_response(help_buffer);
 
-            memset(help_buffer, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
-            snprintf(help_buffer, OUTGOING_RESPONSE_BUFFER_SIZE, "\nFree heap: %u bytes\n", xFreeHeapSpace);
-            send_response(help_buffer);
+        reset_request_buffer();
+        break;
 
-            memset(help_buffer, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
-            snprintf(help_buffer, OUTGOING_RESPONSE_BUFFER_SIZE, "This is version %s.\n", CREATURE_FIRMWARE_VERSION_STRING);
-            send_response(help_buffer);
+    case 'I':
+        info("info command");
 
-            reset_request_buffer();
-            break;
+        char info_buffer[OUTGOING_RESPONSE_BUFFER_SIZE];
 
-        case 'I':
-            info("info command");
+        memset(info_buffer, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
+        snprintf(info_buffer, OUTGOING_RESPONSE_BUFFER_SIZE,
+                 "{\"version\": \"%s\", \"free_heap\": %u, \"uptime\": %lu}", CREATURE_FIRMWARE_VERSION_STRING,
+                 xFreeHeapSpace, to_ms_since_boot(get_absolute_time()));
+        send_response(info_buffer);
 
-            char info_buffer[OUTGOING_RESPONSE_BUFFER_SIZE];
+        reset_request_buffer();
+        break;
 
-            memset(info_buffer, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
-            snprintf(info_buffer, OUTGOING_RESPONSE_BUFFER_SIZE, "{\"version\": \"%s\", \"free_heap\": %u, \"uptime\": %lu}",
-                     CREATURE_FIRMWARE_VERSION_STRING,
-                     xFreeHeapSpace,
-                     to_ms_since_boot(get_absolute_time()));
-            send_response(info_buffer);
+    case 'P':
+        info("printing incoming data buffer");
+        print_incoming_data_buffer();
+        reset_request_buffer();
+        break;
 
-            reset_request_buffer();
-            break;
+    case 'R':
+        info("rebooting...");
+        send_response("BYE!");
+        vTaskDelay(pdMS_TO_TICKS(30)); // Give the response time to send
+        reboot();
+        break;
 
-        case 'P':
-            info("printing incoming data buffer");
-            print_incoming_data_buffer();
-            reset_request_buffer();
-            break;
+    case 'L':
+        info("loading data...");
 
-        case 'R':
-            info("rebooting...");
-            send_response("BYE!");
-            vTaskDelay(pdMS_TO_TICKS(30)); // Give the response time to send
-            reboot();
-            break;
+        // Move the buffer pointer to the start of the data
+        char *ending_pointer;
+        u8 *data = buffer + 1;
+        long size = strtol((char *)data, &ending_pointer, 10);
 
-        case 'L':
-            info("loading data...");
-
-            // Move the buffer pointer to the start of the data
-            char *ending_pointer;
-            u8 *data = buffer + 1;
-            long size = strtol((char*)data, &ending_pointer, 10);
-
-            // Check for any errors during conversion
-            if ((errno == ERANGE && (size == LONG_MAX || size == LONG_MIN)) || size > UINT32_MAX) {
-                info("Conversion error occurred: out of range");
-                send_response("ERR Size is out of range");
-                reset_request_buffer();
-                break;
-            }
-
-            if (*ending_pointer != '\0') {
-                warning("Conversion error: non-numeric characters found: %s\n", ending_pointer);
-                send_response("ERR Size is non-numeric");
-                reset_request_buffer();
-                break;
-            }
-
-            program_size = (u32)size;
-            debug("program size: %u", program_size);
-
-            if(program_size == 0) {
-                warning("Conversion error: size is zero");
-                send_response("ERR Size is zero");
-                reset_request_buffer();
-                break;
-            }
-
-            if(program_size > INCOMING_BUFFER_SIZE) {
-                warning("Conversion error: size is too large");
-
-                char response[OUTGOING_RESPONSE_BUFFER_SIZE];
-                memset(response, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
-                snprintf(response, OUTGOING_RESPONSE_BUFFER_SIZE, "ERR Size too large: %lu (max is %lu)",
-                         program_size,
-                         (u32)INCOMING_BUFFER_SIZE);
-
-                send_response(response);
-                reset_request_buffer();
-                break;
-            }
-
-            // Reset the buffer and switch to the FILLING_BUFFER state
-            reset_incoming_buffer();
-            programmer_state = FILLING_BUFFER;
-            send_response("GO_AHEAD");
+        // Check for any errors during conversion
+        if ((errno == ERANGE && (size == LONG_MAX || size == LONG_MIN)) || size > UINT32_MAX) {
+            info("Conversion error occurred: out of range");
+            send_response("ERR Size is out of range");
             reset_request_buffer();
             break;
+        }
 
-//        case 'D':
-//            info("loading data...");
-//
-//            // Move the buffer pointer to the start of the data
-//            char *ending_pointer;
-//            u8 *data = buffer + 1;
-//            long size = strtol((char*)data, &ending_pointer, 10);
-//
-//            // Check for any errors during conversion
-//            if ((errno == ERANGE && (size == LONG_MAX || size == LONG_MIN)) || size > UINT32_MAX) {
-//                info("Conversion error occurred: out of range");
-//                send_response("ERR Size is out of range");
-//                reset_request_buffer();
-//                break;
-//            }
-//
-//            if (*ending_pointer != '\0') {
-//                warning("Conversion error: non-numeric characters found: %s\n", ending_pointer);
-//                send_response("ERR Size is non-numeric");
-//                reset_request_buffer();
-//                break;
-//            }
-//
-//            program_size = (u32)size;
-//            debug("program size: %u", program_size);
-//
-//            if(program_size == 0) {
-//                warning("Conversion error: size is zero");
-//                send_response("ERR Size is zero");
-//                reset_request_buffer();
-//                break;
-//            }
-//
-//            if(program_size > INCOMING_BUFFER_SIZE) {
-//                warning("Conversion error: size is too large");
-//
-//                char response[OUTGOING_RESPONSE_BUFFER_SIZE];
-//                memset(response, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
-//                snprintf(response, OUTGOING_RESPONSE_BUFFER_SIZE, "ERR Size too large: %lu (max is %lu)",
-//                         program_size,
-//                         (u32)INCOMING_BUFFER_SIZE);
-//
-//                send_response(response);
-//                reset_request_buffer();
-//                break;
-//            }
-//
-//            // Reset the buffer and switch to the FILLING_BUFFER state
-//            reset_incoming_buffer();
-//            programmer_state = FILLING_BUFFER;
-//            send_response("GO_AHEAD");
-//            reset_request_buffer();
-//            break;
+        if (*ending_pointer != '\0') {
+            warning("Conversion error: non-numeric characters found: %s\n", ending_pointer);
+            send_response("ERR Size is non-numeric");
+            reset_request_buffer();
+            break;
+        }
 
-        default:
-            warning("unknown command: %s", buffer);
+        program_size = (u32)size;
+        debug("program size: %u", program_size);
+
+        if (program_size == 0) {
+            warning("Conversion error: size is zero");
+            send_response("ERR Size is zero");
+            reset_request_buffer();
+            break;
+        }
+
+        if (program_size > INCOMING_BUFFER_SIZE) {
+            warning("Conversion error: size is too large");
 
             char response[OUTGOING_RESPONSE_BUFFER_SIZE];
             memset(response, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
-            snprintf(response, OUTGOING_RESPONSE_BUFFER_SIZE, "ERR Unknown command: %s (use H for help)", buffer);
+            snprintf(response, OUTGOING_RESPONSE_BUFFER_SIZE, "ERR Size too large: %lu (max is %lu)", program_size,
+                     (u32)INCOMING_BUFFER_SIZE);
 
             send_response(response);
             reset_request_buffer();
             break;
+        }
+
+        // Reset the buffer and switch to the FILLING_BUFFER state
+        reset_incoming_buffer();
+        programmer_state = FILLING_BUFFER;
+        send_response("GO_AHEAD");
+        reset_request_buffer();
+        break;
+
+        //        case 'D':
+        //            info("loading data...");
+        //
+        //            // Move the buffer pointer to the start of the data
+        //            char *ending_pointer;
+        //            u8 *data = buffer + 1;
+        //            long size = strtol((char*)data, &ending_pointer, 10);
+        //
+        //            // Check for any errors during conversion
+        //            if ((errno == ERANGE && (size == LONG_MAX || size == LONG_MIN)) || size > UINT32_MAX) {
+        //                info("Conversion error occurred: out of range");
+        //                send_response("ERR Size is out of range");
+        //                reset_request_buffer();
+        //                break;
+        //            }
+        //
+        //            if (*ending_pointer != '\0') {
+        //                warning("Conversion error: non-numeric characters found: %s\n", ending_pointer);
+        //                send_response("ERR Size is non-numeric");
+        //                reset_request_buffer();
+        //                break;
+        //            }
+        //
+        //            program_size = (u32)size;
+        //            debug("program size: %u", program_size);
+        //
+        //            if(program_size == 0) {
+        //                warning("Conversion error: size is zero");
+        //                send_response("ERR Size is zero");
+        //                reset_request_buffer();
+        //                break;
+        //            }
+        //
+        //            if(program_size > INCOMING_BUFFER_SIZE) {
+        //                warning("Conversion error: size is too large");
+        //
+        //                char response[OUTGOING_RESPONSE_BUFFER_SIZE];
+        //                memset(response, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
+        //                snprintf(response, OUTGOING_RESPONSE_BUFFER_SIZE, "ERR Size too large: %lu (max is %lu)",
+        //                         program_size,
+        //                         (u32)INCOMING_BUFFER_SIZE);
+        //
+        //                send_response(response);
+        //                reset_request_buffer();
+        //                break;
+        //            }
+        //
+        //            // Reset the buffer and switch to the FILLING_BUFFER state
+        //            reset_incoming_buffer();
+        //            programmer_state = FILLING_BUFFER;
+        //            send_response("GO_AHEAD");
+        //            reset_request_buffer();
+        //            break;
+
+    default:
+        warning("unknown command: %s", buffer);
+
+        char response[OUTGOING_RESPONSE_BUFFER_SIZE];
+        memset(response, '\0', OUTGOING_RESPONSE_BUFFER_SIZE);
+        snprintf(response, OUTGOING_RESPONSE_BUFFER_SIZE, "ERR Unknown command: %s (use H for help)", buffer);
+
+        send_response(response);
+        reset_request_buffer();
+        break;
     }
 }
-
 
 void terminate_shell() {
 
@@ -277,12 +275,7 @@ void launch_shell() {
     reset_request_buffer();
     reset_incoming_buffer();
 
-    xTaskCreate(shell_task,
-                "shell_task",
-                configMINIMAL_STACK_SIZE + 256,
-                NULL,
-                1,
-                &shell_task_handle);
+    xTaskCreate(shell_task, "shell_task", configMINIMAL_STACK_SIZE + 256, NULL, 1, &shell_task_handle);
     info("shell task launched");
 }
 
@@ -303,7 +296,8 @@ void send_response(const char *response) {
     // Make a buffer to hold the response
     u32 incoming_length = strlen(response);
 
-    u32 message_length = incoming_length < OUTGOING_RESPONSE_BUFFER_SIZE ? incoming_length : OUTGOING_RESPONSE_BUFFER_SIZE;
+    u32 message_length =
+        incoming_length < OUTGOING_RESPONSE_BUFFER_SIZE ? incoming_length : OUTGOING_RESPONSE_BUFFER_SIZE;
 
     u32 buffer_size = message_length + 2; // Add 2 for newline and null-terminator
     char *response_buffer = pvPortMalloc(buffer_size);
@@ -325,10 +319,8 @@ void send_response(const char *response) {
     cdc_send(response_buffer);
     goto exit_point;
 
-
-
-    exit_point:
-    if(response_buffer != NULL)
+exit_point:
+    if (response_buffer != NULL)
         vPortFree(response_buffer);
 }
 
@@ -341,12 +333,10 @@ portTASK_FUNCTION(shell_task, pvParameters) {
     // Not a lot to do right now
     for (EVER) {
         vTaskDelay(pdMS_TO_TICKS(5000));
-        debug("shell active. incomingBufferIndex: %lu, requestBufferIndex %lu",
-              incomingBufferIndex, requestBufferIndex);
+        debug("shell active. incomingBufferIndex: %lu, requestBufferIndex %lu", incomingBufferIndex,
+              requestBufferIndex);
     }
-
 }
-
 
 // Automatically called by TinyUSB when data is received
 void tud_cdc_rx_cb(__attribute__((unused)) uint8_t itf) {
@@ -355,7 +345,8 @@ void tud_cdc_rx_cb(__attribute__((unused)) uint8_t itf) {
 
     // Get the number of available bytes
     u32 count = tud_cdc_available();
-    if (count == 0) return;  // Nothing to chew on yet!
+    if (count == 0)
+        return; // Nothing to chew on yet!
 
     // Temporary buffer to hold incoming data
     u8 tempBuffer[count];
@@ -378,60 +369,58 @@ void tud_cdc_rx_cb(__attribute__((unused)) uint8_t itf) {
 
         // Process data based on the current state of our programmer
         switch (programmer_state) {
-            case FILLING_BUFFER:
-                // Reserve one byte for null termination
-                if (incomingBufferIndex < INCOMING_BUFFER_SIZE - 1) {
-                    incoming_data_buffer[incomingBufferIndex++] = ch;
-                    debug("Incoming buffer index: %u", incomingBufferIndex);
+        case FILLING_BUFFER:
+            // Reserve one byte for null termination
+            if (incomingBufferIndex < INCOMING_BUFFER_SIZE - 1) {
+                incoming_data_buffer[incomingBufferIndex++] = ch;
+                debug("Incoming buffer index: %u", incomingBufferIndex);
 
-                    // Check if we've received the expected number of bytes
-                    if (incomingBufferIndex == program_size) {
-                        // Null-terminate right after the last valid byte
-                        incoming_data_buffer[incomingBufferIndex] = '\0';
-                        programmer_state = IDLE;
-                        info("All data received; switching to IDLE state");
-                        send_response("OK");
-                    }
-                } else {
-                    warning("Buffer overflow in incoming data buffer");
-                    programmer_state = ERROR;
+                // Check if we've received the expected number of bytes
+                if (incomingBufferIndex == program_size) {
+                    // Null-terminate right after the last valid byte
+                    incoming_data_buffer[incomingBufferIndex] = '\0';
+                    programmer_state = IDLE;
+                    info("All data received; switching to IDLE state");
+                    send_response("OK");
                 }
-                break;
+            } else {
+                warning("Buffer overflow in incoming data buffer");
+                programmer_state = ERROR;
+            }
+            break;
 
-            case IDLE:
-                if (ch == 0x1B) {  // Escape: reset buffers (a clean slate, like fresh lettuce!)
-                    debug("Received ESC - resetting buffers");
-                    reset_request_buffer();
-                    reset_incoming_buffer();
+        case IDLE:
+            if (ch == 0x1B) { // Escape: reset buffers (a clean slate, like fresh lettuce!)
+                debug("Received ESC - resetting buffers");
+                reset_request_buffer();
+                reset_incoming_buffer();
+                break;
+            } else if (ch == 0x0A || ch == 0x0D) { // Newline: end of command
+                if (requestBufferIndex == 0) {
+                    warning("Skipping blank input line from sender");
                     break;
                 }
-                else if (ch == 0x0A || ch == 0x0D) {  // Newline: end of command
-                    if (requestBufferIndex == 0) {
-                        warning("Skipping blank input line from sender");
-                        break;
-                    }
-                    // Null-terminate the request and process it
-                    request_buffer[requestBufferIndex] = '\0';
-                    handle_shell_command(request_buffer);
-                    // Reset the request buffer after processing the command
+                // Null-terminate the request and process it
+                request_buffer[requestBufferIndex] = '\0';
+                handle_shell_command(request_buffer);
+                // Reset the request buffer after processing the command
+                reset_request_buffer();
+            } else {
+                // Append to the request buffer if there's room
+                if (requestBufferIndex < INCOMING_REQUEST_BUFFER_SIZE - 1) {
+                    request_buffer[requestBufferIndex++] = ch;
+                    debug("Request buffer index: %u", requestBufferIndex);
+                } else {
+                    warning("Request buffer overflow on incoming request");
+                    // Reset the request buffer to start fresh on next command
                     reset_request_buffer();
                 }
-                else {
-                    // Append to the request buffer if there's room
-                    if (requestBufferIndex < INCOMING_REQUEST_BUFFER_SIZE - 1) {
-                        request_buffer[requestBufferIndex++] = ch;
-                        debug("Request buffer index: %u", requestBufferIndex);
-                    } else {
-                        warning("Request buffer overflow on incoming request");
-                        // Reset the request buffer to start fresh on next command
-                        reset_request_buffer();
-                    }
-                }
-                break;
+            }
+            break;
 
-            default:
-                warning("Received data in an unexpected state: %d", programmer_state);
-                break;
+        default:
+            warning("Received data in an unexpected state: %d", programmer_state);
+            break;
         }
     }
 
@@ -441,12 +430,10 @@ void tud_cdc_rx_cb(__attribute__((unused)) uint8_t itf) {
     }
 }
 
-
-
 void print_incoming_data_buffer() {
 
     // Make sure we're not trying to print nothing
-    if(incoming_data_buffer == NULL || incomingBufferIndex == 0) {
+    if (incoming_data_buffer == NULL || incomingBufferIndex == 0) {
         warning("No data to print");
         return;
     }
@@ -464,8 +451,8 @@ void print_incoming_data_buffer() {
         }
 
         // Append the next byte to the current line, checking buffer space
-        snprintf(line_buffer + strlen(line_buffer), sizeof(line_buffer) - strlen(line_buffer), "%02X ", incoming_data_buffer[i]);
-
+        snprintf(line_buffer + strlen(line_buffer), sizeof(line_buffer) - strlen(line_buffer), "%02X ",
+                 incoming_data_buffer[i]);
 
         // If 32 bytes have been added, or it's the end of the data, print the line
         if (i % 32 == 31 || i == incomingBufferIndex - 1) {

--- a/firmware/src/sensor/sensor.c
+++ b/firmware/src/sensor/sensor.c
@@ -10,6 +10,7 @@
 #include "pico/stdlib.h"
 
 #include "controller/controller.h"
+#include "device/eeprom_hours.h"
 #include "device/mcp3304.h"
 #include "device/mcp9808.h"
 #include "device/pac1954.h"
@@ -19,7 +20,6 @@
 #include "controller/config.h"
 #include "sensor.h"
 #include "types.h"
-
 
 // From i2c.c
 extern volatile bool i2c_setup_completed;
@@ -34,7 +34,6 @@ extern analog_filter sensed_motor_position[CONTROLLER_MOTORS_PER_MODULE];
 u64 i2c_timer_count = 0;
 u64 spi_timer_count = 0;
 sensor_power_data_t sensor_power_data[I2C_PAC1954_SENSOR_COUNT];
-
 
 /**
  * The current temperature of the board, in freedom degrees 🦅
@@ -59,8 +58,6 @@ TimerHandle_t i2c_sensor_read_timer = NULL;
 TimerHandle_t spi_sensor_read_timer = NULL;
 #endif
 
-
-
 /**
  * Set up the sensors
  *
@@ -80,7 +77,7 @@ void sensor_init() {
     board_temperature = 66.6;
 
     // Initialize the motor power data metrics
-    for(int i = 0; i < I2C_PAC1954_SENSOR_COUNT; i++) {
+    for (int i = 0; i < I2C_PAC1954_SENSOR_COUNT; i++) {
         sensor_power_data[i].voltage = 0.0f;
         sensor_power_data[i].current = 0.0f;
         sensor_power_data[i].power = 0.0f;
@@ -92,12 +89,11 @@ void sensor_start() {
     debug("starting sensors");
 
     // Create the timer that reads the i2c sensors
-    i2c_sensor_read_timer = xTimerCreate(
-            "I2C Sensor Read Timer",                    // Timer name
-            pdMS_TO_TICKS(SENSOR_I2C_TIMER_TIME_MS),    // Fire every SENSOR_TIMER_TIME_MS
-            pdTRUE,                                     // Auto-reload
-            (void *) 0,                                 // Timer ID (not used here)
-            i2c_sensor_read_timer_callback              // Callback function
+    i2c_sensor_read_timer = xTimerCreate("I2C Sensor Read Timer",                 // Timer name
+                                         pdMS_TO_TICKS(SENSOR_I2C_TIMER_TIME_MS), // Fire every SENSOR_TIMER_TIME_MS
+                                         pdTRUE,                                  // Auto-reload
+                                         (void *)0,                               // Timer ID (not used here)
+                                         i2c_sensor_read_timer_callback           // Callback function
     );
 
     // Make sure this gets created
@@ -108,15 +104,13 @@ void sensor_start() {
 
     info("started i2c sensor read timer");
 
-
 #ifdef CC_VER2
     // Create the timer that reads the spi sensors
-    spi_sensor_read_timer = xTimerCreate(
-            "SPI Sensor Read Timer",                    // Timer name
-            pdMS_TO_TICKS(SENSOR_SPI_TIMER_TIME_MS),    // Fire every SENSOR_SPI_TIMER_TIME_MS
-            pdTRUE,                                     // Auto-reload
-            (void *) 0,                                 // Timer ID (not used here)
-            spi_sensor_read_timer_callback              // Callback function
+    spi_sensor_read_timer = xTimerCreate("SPI Sensor Read Timer",                 // Timer name
+                                         pdMS_TO_TICKS(SENSOR_SPI_TIMER_TIME_MS), // Fire every SENSOR_SPI_TIMER_TIME_MS
+                                         pdTRUE,                                  // Auto-reload
+                                         (void *)0,                               // Timer ID (not used here)
+                                         spi_sensor_read_timer_callback           // Callback function
     );
 
     // Make sure this gets created
@@ -132,40 +126,44 @@ void sensor_start() {
 /*
  * Note to future me! 😅
  *
- * Remember that's there's only one I2C bus in use, and we can't have
- * several things trying to use it at once.
+ * There is only one I2C bus, and it has no mutex. Everything that touches it
+ * must run in the FreeRTOS timer-daemon task so the callbacks are serialized
+ * by the daemon itself - that single-owner rule is what keeps the bus safe.
  *
- * As tempting as it might seem, do not break the timer callback functions
- * up into separate timers. It will not end well.
+ * Two things rely on this: this sensor read callback, and the power-on hours
+ * odometer's persist timer (see eeprom.c). Both are software timers, so they
+ * can never run at the same time. The real hazard - the thing that *will* end
+ * badly - is moving any I2C access into its own task without first adding a
+ * bus mutex. So: keep the sensor reads in this one callback, and never let
+ * I2C escape the timer daemon.
  */
-
 
 void i2c_sensor_read_timer_callback(TimerHandle_t xTimer) {
 
     // We don't use this on this timer
-    (void) xTimer;
+    (void)xTimer;
 
     board_temperature = mcp9808_read_temperature_f(SENSORS_I2C_BUS, I2C_DEVICE_MCP9808);
-//    verbose("board temperature: %.2fF", board_temperature);
+    //    verbose("board temperature: %.2fF", board_temperature);
 
     int i = 0;
     // Read the power data for all of our sensors
 
 #ifdef CC_VER2
-    for(; i < I2C_MOTOR0_PAC1954_SENSOR_COUNT; i++) {
+    for (; i < I2C_MOTOR0_PAC1954_SENSOR_COUNT; i++) {
         sensor_power_data[i].voltage = pac1954_read_voltage(I2C_MOTOR0_PAC1954, i);
-        sensor_power_data[i].current = pac1954_read_current(I2C_MOTOR0_PAC1954,i);
+        sensor_power_data[i].current = pac1954_read_current(I2C_MOTOR0_PAC1954, i);
         sensor_power_data[i].power = pac1954_read_power(I2C_MOTOR0_PAC1954, i);
     }
-//    verbose("motor0 power data: %f %f %f %f",
-//            sensor_power_data[0].power,
-//            sensor_power_data[1].power,
-//            sensor_power_data[2].power,
-//            sensor_power_data[3].power);
+    //    verbose("motor0 power data: %f %f %f %f",
+    //            sensor_power_data[0].power,
+    //            sensor_power_data[1].power,
+    //            sensor_power_data[2].power,
+    //            sensor_power_data[3].power);
 
-    for(; i < I2C_MOTOR1_PAC1954_SENSOR_COUNT; i++) {
+    for (; i < I2C_MOTOR1_PAC1954_SENSOR_COUNT; i++) {
         sensor_power_data[i].voltage = pac1954_read_voltage(I2C_MOTOR1_PAC1954, i);
-        sensor_power_data[i].current = pac1954_read_current(I2C_MOTOR1_PAC1954,i);
+        sensor_power_data[i].current = pac1954_read_current(I2C_MOTOR1_PAC1954, i);
         sensor_power_data[i].power = pac1954_read_power(I2C_MOTOR1_PAC1954, i);
     }
 //    verbose("motor1 power data: %f %f %f %f",
@@ -175,17 +173,16 @@ void i2c_sensor_read_timer_callback(TimerHandle_t xTimer) {
 //            sensor_power_data[7].power);
 #endif
 
-
-    for(; i < I2C_BOARD_PAC1954_SENSOR_COUNT; i++) {
+    for (; i < I2C_BOARD_PAC1954_SENSOR_COUNT; i++) {
         sensor_power_data[i].voltage = pac1954_read_voltage(I2C_BOARD_PAC1954, i);
-        sensor_power_data[i].current = pac1954_read_current(I2C_BOARD_PAC1954,i);
+        sensor_power_data[i].current = pac1954_read_current(I2C_BOARD_PAC1954, i);
         sensor_power_data[i].power = pac1954_read_power(I2C_BOARD_PAC1954, i);
     }
-//    verbose("board power data: %f %f %f %f",
-//            sensor_power_data[8].power,
-//            sensor_power_data[9].power,
-//            sensor_power_data[10].power,
-//            sensor_power_data[11].power);
+    //    verbose("board power data: %f %f %f %f",
+    //            sensor_power_data[8].power,
+    //            sensor_power_data[9].power,
+    //            sensor_power_data[10].power,
+    //            sensor_power_data[11].power);
 
     // Send refresh command to get fresh data for next pass
 #ifdef CC_VER2
@@ -194,43 +191,41 @@ void i2c_sensor_read_timer_callback(TimerHandle_t xTimer) {
 #endif
 
     pac1954_refresh(I2C_BOARD_PAC1954);
+
+#if USE_EEPROM && defined(CC_VER3)
+    // Feed the freshly-read motor-power-rail voltage to the odometer so it can
+    // tally motor-powered time. This is pure arithmetic - no bus access - so
+    // it is safe to do here in the sensor callback.
+    eeprom_hours_motor_sample(sensor_power_data[INCOMING_MOTOR_POWER_SENSOR_SLOT].voltage);
+#endif
+
     i2c_timer_count += 1;
-
 }
-
 
 #ifdef CC_VER2
 void spi_sensor_read_timer_callback(TimerHandle_t xTimer) {
 
     // We don't use this on this timer
-    (void) xTimer;
+    (void)xTimer;
 
     // Read all the pins and update the filter map
-    for(int i = 0; i < CONTROLLER_MOTORS_PER_MODULE; i++) {
+    for (int i = 0; i < CONTROLLER_MOTORS_PER_MODULE; i++) {
 
         // Read the ADC value
         u16 adc_value = adc_read(i, SENSORS_SPI_CS_PIN);
 
         // Update the filter
         analog_filter_update(&sensed_motor_position[i], adc_value);
-
     }
 
     spi_timer_count += 1;
 
-    if(spi_timer_count % SENSORS_SPI_LOG_CYCLES == 0) {
-        debug("sensed motor positions: %u %u %u %u %u %u %u %u",
-              analog_filter_get_value(&sensed_motor_position[0]),
-              analog_filter_get_value(&sensed_motor_position[1]),
-              analog_filter_get_value(&sensed_motor_position[2]),
-              analog_filter_get_value(&sensed_motor_position[3]),
-              analog_filter_get_value(&sensed_motor_position[4]),
-              analog_filter_get_value(&sensed_motor_position[5]),
-              analog_filter_get_value(&sensed_motor_position[6]),
+    if (spi_timer_count % SENSORS_SPI_LOG_CYCLES == 0) {
+        debug("sensed motor positions: %u %u %u %u %u %u %u %u", analog_filter_get_value(&sensed_motor_position[0]),
+              analog_filter_get_value(&sensed_motor_position[1]), analog_filter_get_value(&sensed_motor_position[2]),
+              analog_filter_get_value(&sensed_motor_position[3]), analog_filter_get_value(&sensed_motor_position[4]),
+              analog_filter_get_value(&sensed_motor_position[5]), analog_filter_get_value(&sensed_motor_position[6]),
               analog_filter_get_value(&sensed_motor_position[7]));
     }
-
-
 }
 #endif
-

--- a/firmware/src/sensor/sensor.c
+++ b/firmware/src/sensor/sensor.c
@@ -192,7 +192,7 @@ void i2c_sensor_read_timer_callback(TimerHandle_t xTimer) {
 
     pac1954_refresh(I2C_BOARD_PAC1954);
 
-#if USE_EEPROM && defined(CC_VER3)
+#if USE_POWER_HOURS && defined(CC_VER3)
     // Feed the freshly-read motor-power-rail voltage to the odometer so it can
     // tally motor-powered time. This is pure arithmetic - no bus access - so
     // it is safe to do here in the sensor callback.

--- a/firmware/src/usb/usb.c
+++ b/firmware/src/usb/usb.c
@@ -4,12 +4,25 @@
  *
  * This module handles USB device initialization, monitoring connection status,
  * and CDC communication for the creature controller firmware.
+ *
+ * TinyUSB is built with CFG_TUSB_OS = OPT_OS_NONE, which provides no
+ * cross-context locking for its CDC FIFO / endpoint state. It is only safe
+ * when a *single* execution context drives the device stack and performs all
+ * CDC writes (the TinyUSB dcd ISR is the only other toucher, and TinyUSB
+ * guards that itself). Earlier designs called tud_task() from the timer
+ * daemon while writing CDC from a separate task; the resulting race with the
+ * USB hardware ISR corrupted in-flight transfers (one message truncated, the
+ * next spliced into it). usb_device_task below is now the sole owner of every
+ * tud_* call: it pumps tud_task(), drains the outgoing queue, and tracks the
+ * connection state - no timers, no mutex, one context.
  */
 
 #include <stddef.h>
+#include <string.h>
 
 #include <FreeRTOS.h>
-#include <timers.h>
+#include <queue.h>
+#include <task.h>
 
 #include <hardware/gpio.h>
 
@@ -27,13 +40,33 @@ bool device_mounted = false;
 u32 events_processed = 0;
 bool cdc_connected = false;
 
+// Times the CDC TX FIFO could not take a whole message in one write (host
+// backpressure). The message is NOT lost - it resumes on the next loop once
+// tud_task() has drained the FIFO. A growing value just means a slow host.
+volatile u64 usb_tx_fifo_full = 0;
+
+static TaskHandle_t usb_device_task_handle = NULL;
+
+// Outgoing transport queue, created in usb_serial_init().
+extern QueueHandle_t usb_serial_outgoing_messages;
+extern bool outgoing_usb_queue_exists;
+
+// Stat shared with the STATS reporter (USB_SENT).
+extern volatile u64 usb_serial_messages_sent;
+
+// Outbound drop counter (STATS: OUT_DROP). The pipeline never blocks - it
+// drops and counts. The USB task adds to this when it discards a stale
+// backlog (disconnected) or abandons a wedged message.
+extern volatile u64 outgoing_messages_dropped;
+
+portTASK_FUNCTION_PROTO(usb_device_task, pvParameters);
+
 /**
  * @brief Initialize the USB subsystem
  *
- * This function initializes the TinyUSB stack and configures the device
- * stack on the root hub port. It also sets up the LED indicator for USB status.
- * Note that this should be called after the RTOS scheduler is started since
- * the USB IRQ handler uses RTOS queue APIs.
+ * Initializes the TinyUSB stack and the device stack on the root hub port,
+ * and configures the USB-status LED. Must be called after the RTOS scheduler
+ * is started since the USB IRQ handler uses RTOS APIs.
  */
 void usb_init() {
     // Initialize TinyUSB stack
@@ -51,93 +84,139 @@ void usb_init() {
 }
 
 /**
- * @brief Start USB service timers
+ * @brief Start the single USB device task
  *
- * Creates and starts two FreeRTOS timers:
- * 1. Device service timer: runs at 1ms interval to call tud_task()
- * 2. CDC connection monitor timer: runs at 100ms interval to check connection status
- *
- * These timers handle USB stack processing and connection state monitoring
- * without blocking the main application tasks.
+ * One task owns the entire device stack: it services tud_task(), transmits
+ * queued CDC messages, and monitors the connection. This replaces the old
+ * 1 ms / 100 ms timers and the separate outbound writer task.
  */
 void usb_start() {
-    // Create timer for USB device tasks (runs every 1ms)
-    TimerHandle_t usbDeviceTimer = xTimerCreate(
-            "usbDeviceTimer",           // Timer name
-            pdMS_TO_TICKS(1),           // Every millisecond
-            pdTRUE,                     // Auto-reload
-            (void *) 0,                 // Timer ID (not used here)
-            usbDeviceTimerCallback      // Callback function
-    );
-
-    // Create timer to monitor CDC connection status (runs every 100ms)
-    TimerHandle_t cdcConnectedTimer = xTimerCreate(
-            "cdcConnectedTimer",        // Timer name
-            pdMS_TO_TICKS(100),         // Every 100ms
-            pdTRUE,                     // Auto-reload
-            (void *) 0,                 // Timer ID (not used here)
-            is_cdc_connected_timer      // Callback function
-    );
-
-    // Verify timer creation was successful
-    configASSERT(usbDeviceTimer != NULL);
-
-    // Start both timers
-    xTimerStart(usbDeviceTimer, 0);
-    xTimerStart(cdcConnectedTimer, 0);
-
-    info("USB service timer started");
+    const BaseType_t ok = xTaskCreate(usb_device_task, "usb_device_task", USB_DEVICE_TASK_STACK_SIZE, NULL,
+                                      USB_DEVICE_TASK_PRIORITY, &usb_device_task_handle);
+    configASSERT(ok == pdPASS);
+    info("USB device task started");
 }
 
 /**
- * @brief USB device timer callback
+ * @brief Reconcile CDC connection state, LED, and controller notification
  *
- * This callback is invoked every 1ms to process TinyUSB tasks.
- * It ensures the USB stack gets regular processing time without
- * blocking other operations.
- *
- * @param xTimer Timer handle (unused)
+ * Called only from usb_device_task (same context as tud_task()), so the
+ * tud_cdc_connected() read needs no locking.
  */
-void usbDeviceTimerCallback(TimerHandle_t xTimer) {
+static void service_cdc_connection(void) {
+    const bool connected = tud_cdc_connected();
 
-    (void) xTimer;  // Unused parameter
+    gpio_put(USB_MOUNTED_LED_PIN, connected);
 
-    tud_task();  // Process TinyUSB tasks
+    if (connected && !cdc_connected) {
+        debug("CDC connected");
+        cdc_connected = true;
+        controller_connected();
+    } else if (!connected && cdc_connected) {
+        debug("CDC disconnected");
+        cdc_connected = false;
+        controller_disconnected();
+    }
 }
 
 /**
- * @brief CDC connection monitoring timer callback
+ * @brief The one and only owner of the TinyUSB device stack
  *
- * Checks if the CDC connection state has changed and updates the LED indicator.
- * When connection state changes, it notifies the controller module so it can
- * take appropriate action (e.g., start/stop tasks that depend on CDC).
- *
- * @param xTimer Timer handle (unused)
+ * Loop: service the stack, make non-blocking progress transmitting queued CDC
+ * messages (resuming a partially-written message across iterations so nothing
+ * is ever truncated or blocked), and periodically reconcile the connection
+ * state. Pacing matches the old 1 ms timer cadence and yields every pass.
  */
-void is_cdc_connected_timer(TimerHandle_t xTimer) {
+portTASK_FUNCTION(usb_device_task, pvParameters) {
 
-    (void) xTimer;  // Unused parameter
+    (void)pvParameters;
 
-    if (tud_cdc_connected()) {
-        // CDC is connected
-        gpio_put(USB_MOUNTED_LED_PIN, true);  // Turn on LED
+    configASSERT(outgoing_usb_queue_exists);
 
-        // If this is a new connection (state change)
-        if (!cdc_connected) {
-            debug("CDC connected");
-            cdc_connected = true;
-            controller_connected();  // Notify controller of connection
+    // The message currently being transmitted and how far it has been handed
+    // to the CDC TX FIFO. tx_len == 0 means "no message in flight".
+    static char tx_msg[USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH + 1];
+    size_t tx_len = 0;
+    size_t tx_sent = 0;
+    u32 tx_stalls = 0; // consecutive zero-progress writes for the in-flight message
+
+    u32 conn_check_ticks = 0;
+
+    for (EVER) {
+
+        // 1. Service the device stack: enumeration, events, RX callbacks, and
+        //    draining the CDC TX FIFO to the host.
+        tud_task();
+
+        // 2. Make progress on CDC transmission. Never blocks; single context
+        //    so the byte stream stays correctly framed.
+        if (tud_cdc_connected()) {
+
+            // Drain up to a bounded burst per tick, while the FIFO accepts it.
+            // This keeps the small outgoing queue from filling under normal
+            // bursts (BSENSE + 2 LOG + INIT + STATS) without ever spinning.
+            for (u32 burst = 0; burst < USB_TX_BURST_MAX; burst++) {
+
+                if (tx_len == 0) {
+                    if (xQueueReceive(usb_serial_outgoing_messages, tx_msg, 0) != pdPASS) {
+                        break; // nothing queued
+                    }
+                    tx_msg[USB_SERIAL_OUTGOING_MESSAGE_MAX_LENGTH] = '\0';
+                    tx_len = strlen(tx_msg);
+                    tx_sent = 0;
+                    tx_stalls = 0;
+                }
+
+                const u32 n = tud_cdc_n_write(0, tx_msg + tx_sent, tx_len - tx_sent);
+                tx_sent += n;
+
+                if (tx_sent >= tx_len) {
+                    // Whole message handed to the FIFO, correctly framed.
+                    tx_len = 0;
+                    usb_serial_messages_sent = usb_serial_messages_sent + 1;
+                    continue; // try to drain another from this burst
+                }
+
+                // FIFO has no room right now.
+                usb_tx_fifo_full = usb_tx_fifo_full + 1;
+
+                if (n == 0 && ++tx_stalls >= USB_TX_STALL_LIMIT) {
+                    // This message has made zero progress for too long (host
+                    // not draining / endpoint glitch). Drop it - counted - so
+                    // one wedged message can't permanently halt all telemetry.
+                    // Bounded, never blocks, stream stays framed.
+                    outgoing_messages_dropped = outgoing_messages_dropped + 1;
+                    tx_len = 0;
+                }
+                break; // let tud_task() drain the FIFO; resume next tick
+            }
+
+            tud_cdc_n_write_flush(0);
+
+        } else {
+            // Not connected: don't transmit. Discard the bounded backlog so a
+            // reconnect doesn't replay stale state, and count it so the loss
+            // shows up in OUT_DROP rather than being silent.
+            if (tx_len != 0) {
+                outgoing_messages_dropped = outgoing_messages_dropped + 1;
+                tx_len = 0;
+            }
+            while (xQueueReceive(usb_serial_outgoing_messages, tx_msg, 0) == pdPASS) {
+                outgoing_messages_dropped = outgoing_messages_dropped + 1;
+            }
         }
-    } else {
-        // CDC is disconnected
-        gpio_put(USB_MOUNTED_LED_PIN, false);  // Turn off LED
 
-        // If this is a new disconnection (state change)
-        if (cdc_connected) {
-            debug("CDC disconnected");
-            cdc_connected = false;
-            controller_disconnected();  // Notify controller of disconnection
+        // 3. Periodic connection-state reconciliation.
+        conn_check_ticks += USB_DEVICE_TASK_POLL_MS;
+        if (conn_check_ticks >= USB_CDC_CONNECTION_CHECK_MS) {
+            conn_check_ticks = 0;
+            service_cdc_connection();
         }
+
+        // 4. Pace the loop and yield. A message split across iterations only
+        //    waits this long between chunks, which is plenty given the 8 KB
+        //    CDC FIFO and the trickle of telemetry/log traffic.
+        vTaskDelay(pdMS_TO_TICKS(USB_DEVICE_TASK_POLL_MS));
     }
 }
 
@@ -178,7 +257,7 @@ void tud_umount_cb(void) {
  * @param remote_wakeup_en True if host allows remote wakeup
  */
 void tud_suspend_cb(const bool remote_wakeup_en) {
-    (void) remote_wakeup_en;  // Unused parameter
+    (void)remote_wakeup_en; // Unused parameter
     debug("USB bus suspended");
 
     device_mounted = false;
@@ -194,25 +273,4 @@ void tud_suspend_cb(const bool remote_wakeup_en) {
 void tud_resume_cb(void) {
     debug("USB bus resumed");
     usb_bus_active = true;
-}
-
-//--------------------------------------------------------------------+
-// MARK: - CDC Functions
-//--------------------------------------------------------------------+
-
-/**
- * @brief Send a string message over CDC
- *
- * Sends a null-terminated string message over the CDC interface if connected.
- * If not connected, the message is skipped and a verbose log entry is generated.
- *
- * @param message Null-terminated string message to send
- */
-void cdc_send(char const *message) {
-    if (tud_cdc_connected()) {
-        tud_cdc_n_write_str(0, message);
-        tud_cdc_n_write_flush(0);
-    } else {
-        verbose("skipped CDC send");
-    }
 }

--- a/firmware/src/usb/usb.h
+++ b/firmware/src/usb/usb.h
@@ -5,7 +5,7 @@
 #include <sys/select.h>
 
 #include <FreeRTOS.h>
-#include <timers.h>
+#include <task.h>
 
 #include "tusb.h"
 
@@ -15,13 +15,15 @@
  * @file usb.h
  * @brief USB subsystem interface for creature controller
  *
- * This module provides functions to initialize, start, and interact with the USB
- * subsystem. It handles USB device enumeration, CDC connection monitoring, and
- * message transmission over CDC.
+ * This module provides functions to initialize and start the USB subsystem.
+ * A single task (usb_device_task, in usb.c) owns the entire TinyUSB device
+ * stack: enumeration, CDC transmit, and connection monitoring. There is no
+ * public "send" entry point - producers enqueue onto usb_serial_outgoing_messages
+ * and the USB task drains it (TinyUSB OPT_OS_NONE requires a single context).
  */
 
 // USB configuration
-#define BOARD_TUD_ROOT_HUB_PORT      0    // Root hub port for device mode
+#define BOARD_TUD_ROOT_HUB_PORT 0 // Root hub port for device mode
 
 /**
  * @brief Initialize the USB subsystem
@@ -33,44 +35,9 @@
 void usb_init(void);
 
 /**
- * @brief Start USB service timers
+ * @brief Start the single USB device task
  *
- * Creates and starts the FreeRTOS timers needed for USB operation:
- * - A 1ms timer for USB device tasks processing
- * - A 100ms timer for CDC connection monitoring
- *
- * This function should be called after usb_init().
+ * Creates usb_device_task, the sole owner of every tud_* call (device
+ * servicing, CDC transmit, and connection monitoring). Call after usb_init().
  */
 void usb_start(void);
-
-/**
- * @brief Timer callback for USB device processing
- *
- * Called every 1ms to process TinyUSB tasks, ensuring the USB stack gets
- * regular processing time without blocking other operations.
- *
- * @param xTimer Timer handle that triggered this callback
- */
-void usbDeviceTimerCallback(TimerHandle_t xTimer);
-
-/**
- * @brief Timer callback for CDC connection monitoring
- *
- * Called every 100ms to check if the CDC connection state has changed.
- * Updates the LED indicator and notifies the controller module of
- * connection/disconnection events.
- *
- * @param xTimer Timer handle that triggered this callback
- */
-void is_cdc_connected_timer(TimerHandle_t xTimer);
-
-/**
- * @brief Send a message over CDC interface
- *
- * Transmits a null-terminated string over the CDC interface if connected.
- * If the device is not connected, the message is silently dropped and a
- * verbose log entry is generated.
- *
- * @param message Null-terminated string to transmit
- */
-void cdc_send(const char *message);

--- a/firmware/src/watchdog/watchdog.c
+++ b/firmware/src/watchdog/watchdog.c
@@ -1,11 +1,62 @@
 #include <hardware/watchdog.h>
 
 #include <FreeRTOS.h>
+#include <task.h>
 
 #include "controller/config.h"
 #include "logging/logging.h"
+#include "types.h"
 #include "watchdog.h"
 
+#if USE_WATCHDOG_HEALTH_GATE
+/*
+ * Liveness flag for the watchdog health gate. Set true by the lowest-priority
+ * heartbeat task each time it runs; read-and-cleared by watchdog_feed() in the
+ * PWM-wrap ISR. Single aligned bool -> atomic load/store on Cortex-M, so no
+ * critical section is needed: the only race (task sets it just as the ISR
+ * clears it) merely skips one refresh, recovered on the next ISR cycle, well
+ * inside WATCHDOG_TIMEOUT_MS. Seeded true so the brief startup window between
+ * init_watchdog() and the heartbeat task's first run is covered (the heartbeat
+ * task sets it again within milliseconds of the scheduler starting).
+ */
+static volatile bool watchdog_health_ok = true;
+
+static TaskHandle_t watchdog_heartbeat_task_handle = NULL;
+
+portTASK_FUNCTION(watchdog_heartbeat_task, pvParameters) {
+    (void)pvParameters;
+    for (EVER) {
+        // Re-arm first, then sleep: the scheduler running this lowest-priority
+        // task at all is the liveness proof. Independent of host/comms state.
+        watchdog_health_ok = true;
+        vTaskDelay(pdMS_TO_TICKS(WATCHDOG_HEARTBEAT_PERIOD_MS));
+    }
+}
+#endif
+
+void watchdog_feed(void) {
+#if USE_WATCHDOG_HEALTH_GATE
+    // Refresh only if the scheduler proved liveness since the last refresh.
+    if (watchdog_health_ok) {
+        watchdog_health_ok = false;
+        watchdog_update();
+    }
+#else
+    watchdog_update();
+#endif
+}
+
+void watchdog_health_start(void) {
+#if USE_WATCHDOG_HEALTH_GATE
+    const BaseType_t ok = xTaskCreate(watchdog_heartbeat_task, "wd_heartbeat", WATCHDOG_HEARTBEAT_TASK_STACK, NULL,
+                                      WATCHDOG_HEARTBEAT_TASK_PRIORITY, &watchdog_heartbeat_task_handle);
+    configASSERT(ok == pdPASS);
+    info("Watchdog health gate enabled (heartbeat every %d ms)", WATCHDOG_HEARTBEAT_PERIOD_MS);
+#else
+    // Health gate disabled: watchdog_feed() refreshes unconditionally, exactly
+    // as the original design. Nothing to start.
+#endif
+}
 
 /**
  * @brief Initialize the watchdog timer
@@ -36,7 +87,7 @@ _Noreturn void reboot(void) {
     watchdog_enable(1, 1);
 
     // Enter infinite loop to ensure reset occurs
-    for(EVER) {
+    for (EVER) {
         // Wait for watchdog reset
     }
 }

--- a/firmware/src/watchdog/watchdog.h
+++ b/firmware/src/watchdog/watchdog.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#include <stdbool.h>
-#include <hardware/watchdog.h>
 #include <FreeRTOS.h>
+#include <hardware/watchdog.h>
+#include <stdbool.h>
 #include <timers.h>
 
 /**
@@ -18,11 +18,30 @@
  */
 bool init_watchdog(void);
 
+/**
+ * @brief Refresh the watchdog, applying the health gate
+ *
+ * Called from the PWM-wrap ISR in place of a raw watchdog_update(). When
+ * USE_WATCHDOG_HEALTH_GATE is enabled it refreshes only if the heartbeat task
+ * has run since the last refresh (proving the scheduler is alive); otherwise
+ * it refreshes unconditionally, exactly as the original design. ISR-safe: no
+ * blocking, no FreeRTOS calls.
+ */
+void watchdog_feed(void);
+
+/**
+ * @brief Start the watchdog health-gate heartbeat task
+ *
+ * Creates the lowest-priority heartbeat task whose execution is the liveness
+ * signal watchdog_feed() gates on. No-op when USE_WATCHDOG_HEALTH_GATE is 0.
+ * Call once, before the scheduler starts.
+ */
+void watchdog_health_start(void);
 
 /**
  * @brief Intentionally force a system reboot using the watchdog
  *
  * Enables watchdog with minimum timeout and enters infinite loop
  * to ensure the system resets.
- */ _Noreturn
-void reboot(void);
+ */
+_Noreturn void reboot(void);

--- a/firmware/tests/CMakeLists.txt
+++ b/firmware/tests/CMakeLists.txt
@@ -64,6 +64,13 @@ add_executable(test_dynamixel_protocol
 )
 target_link_libraries(test_dynamixel_protocol unity)
 
+# Create test executable for the power-on hours odometer (pure logic, no hardware)
+add_executable(test_eeprom_hours
+        tests/test_eeprom_hours.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/device/eeprom_hours.c
+)
+target_link_libraries(test_eeprom_hours unity)
+
 # Create test executable for dynamixel servo layer
 # HAL stubs are provided directly in the test file (no real hardware needed)
 add_executable(test_dynamixel_servo
@@ -80,7 +87,8 @@ add_custom_target(run_tests
         COMMAND test_message_parsing
         COMMAND test_dynamixel_protocol
         COMMAND test_dynamixel_servo
-        DEPENDS test_string_utils test_analog_filter test_message_parsing test_dynamixel_protocol test_dynamixel_servo
+        COMMAND test_eeprom_hours
+        DEPENDS test_string_utils test_analog_filter test_message_parsing test_dynamixel_protocol test_dynamixel_servo test_eeprom_hours
 )
 
 # Add exported symbols for mocked functions that are used by the firmware code

--- a/firmware/tests/tests/test_eeprom_hours.c
+++ b/firmware/tests/tests/test_eeprom_hours.c
@@ -1,0 +1,112 @@
+/**
+ * @file test_eeprom_hours.c
+ * @brief Tests for the power-on hours odometer record logic
+ *
+ * Covers CRC-16, record serialize/deserialize round-trips, corruption
+ * rejection, and newest-slot selection across the wear-leveled ring
+ * (including the power-loss / torn-write fallback). No hardware required.
+ */
+
+#include "unity.h"
+
+#include <string.h>
+
+#include "controller/config.h"
+#include "device/eeprom_hours.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/**
+ * CRC-16/CCITT-FALSE has a well-known check value: the ASCII string
+ * "123456789" must produce 0x29B1. This pins the algorithm down.
+ */
+void test_crc16_known_check_value(void) {
+    const u8 data[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9'};
+    TEST_ASSERT_EQUAL_HEX16(0x29B1, eeprom_hours_crc16(data, sizeof(data)));
+}
+
+void test_serialize_deserialize_round_trip(void) {
+    u8 slot[EEPROM_HOURS_SLOT_SIZE];
+    eeprom_hours_serialize(slot, 42, 12345, 6789);
+
+    u32 seq = 0, uptime = 0, motor = 0;
+    TEST_ASSERT_TRUE(eeprom_hours_deserialize(slot, &seq, &uptime, &motor));
+    TEST_ASSERT_EQUAL_UINT32(42, seq);
+    TEST_ASSERT_EQUAL_UINT32(12345, uptime);
+    TEST_ASSERT_EQUAL_UINT32(6789, motor);
+}
+
+void test_deserialize_rejects_bad_magic(void) {
+    u8 slot[EEPROM_HOURS_SLOT_SIZE];
+    eeprom_hours_serialize(slot, 1, 1, 1);
+    slot[0] ^= 0xFF; // Corrupt the magic
+
+    TEST_ASSERT_FALSE(eeprom_hours_deserialize(slot, NULL, NULL, NULL));
+}
+
+void test_deserialize_rejects_corrupt_payload(void) {
+    u8 slot[EEPROM_HOURS_SLOT_SIZE];
+    eeprom_hours_serialize(slot, 7, 1000, 2000);
+    slot[7] ^= 0x01; // Flip a bit in the uptime field; CRC must now fail
+
+    TEST_ASSERT_FALSE(eeprom_hours_deserialize(slot, NULL, NULL, NULL));
+}
+
+void test_select_slot_blank_eeprom_returns_minus_one(void) {
+    u8 region[EEPROM_HOURS_REGION_SIZE];
+    memset(region, 0xFF, sizeof(region)); // Erased EEPROM
+
+    u32 seq = 0, uptime = 0, motor = 0;
+    TEST_ASSERT_EQUAL_INT(-1, eeprom_hours_select_slot(region, sizeof(region), &seq, &uptime, &motor));
+}
+
+void test_select_slot_picks_highest_sequence(void) {
+    u8 region[EEPROM_HOURS_REGION_SIZE];
+    memset(region, 0xFF, sizeof(region));
+
+    // Newest record (seq 100) sits in slot 1; an older one (seq 99) in slot 5.
+    eeprom_hours_serialize(&region[5 * EEPROM_HOURS_SLOT_SIZE], 99, 500, 50);
+    eeprom_hours_serialize(&region[1 * EEPROM_HOURS_SLOT_SIZE], 100, 600, 60);
+
+    u32 seq = 0, uptime = 0, motor = 0;
+    int idx = eeprom_hours_select_slot(region, sizeof(region), &seq, &uptime, &motor);
+
+    TEST_ASSERT_EQUAL_INT(1, idx);
+    TEST_ASSERT_EQUAL_UINT32(100, seq);
+    TEST_ASSERT_EQUAL_UINT32(600, uptime);
+    TEST_ASSERT_EQUAL_UINT32(60, motor);
+}
+
+/**
+ * Power-loss case: the newest slot is half-written (CRC invalid). Selection
+ * must ignore it and fall back to the previous good record.
+ */
+void test_select_slot_falls_back_past_torn_write(void) {
+    u8 region[EEPROM_HOURS_REGION_SIZE];
+    memset(region, 0xFF, sizeof(region));
+
+    eeprom_hours_serialize(&region[2 * EEPROM_HOURS_SLOT_SIZE], 200, 900, 90);
+    eeprom_hours_serialize(&region[3 * EEPROM_HOURS_SLOT_SIZE], 201, 999, 99);
+    region[3 * EEPROM_HOURS_SLOT_SIZE + 9] ^= 0xAA; // Tear the newest record
+
+    u32 seq = 0, uptime = 0, motor = 0;
+    int idx = eeprom_hours_select_slot(region, sizeof(region), &seq, &uptime, &motor);
+
+    TEST_ASSERT_EQUAL_INT(2, idx);
+    TEST_ASSERT_EQUAL_UINT32(200, seq);
+    TEST_ASSERT_EQUAL_UINT32(900, uptime);
+    TEST_ASSERT_EQUAL_UINT32(90, motor);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_crc16_known_check_value);
+    RUN_TEST(test_serialize_deserialize_round_trip);
+    RUN_TEST(test_deserialize_rejects_bad_magic);
+    RUN_TEST(test_deserialize_rejects_corrupt_payload);
+    RUN_TEST(test_select_slot_blank_eeprom_returns_minus_one);
+    RUN_TEST(test_select_slot_picks_highest_sequence);
+    RUN_TEST(test_select_slot_falls_back_past_torn_write);
+    return UNITY_END();
+}

--- a/firmware/tools/raw_cdc_capture.py
+++ b/firmware/tools/raw_cdc_capture.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Byte-faithful USB-CDC capture for diagnosing the BSENSE/LOG splice.
+
+Reads the raw serial stream with no line discipline / no display rendering,
+mirrors it to stdout, and tees it to a file. Use this INSTEAD of Serial.app
+to determine whether the splice is introduced by the firmware/USB or by the
+terminal app. The firmware stamps its own timestamps, so this capture is
+directly comparable to a Serial.app capture.
+
+Usage:
+    python3 tools/raw_cdc_capture.py /dev/cu.usbmodem14202 [outfile]
+
+Quit Serial.app first - only one process can hold the port.
+"""
+import sys
+
+try:
+    import serial  # pyserial
+except ImportError:
+    sys.exit("pyserial not installed: pip3 install pyserial")
+
+port = sys.argv[1] if len(sys.argv) > 1 else "/dev/cu.usbmodem14202"
+outfile = sys.argv[2] if len(sys.argv) > 2 else "/tmp/usb-raw.log"
+
+# 115200,N,8,1 per the firmware's binary-info. For true USB-CDC the baud is
+# nominally a no-op, but this host/driver clearly honors line coding, so set
+# it explicitly to match.
+ser = serial.Serial(port, baudrate=115200, bytesize=8,
+                     parity="N", stopbits=1, timeout=1)
+
+print(f"Capturing {port} @115200 raw -> {outfile} (Ctrl-C to stop)\n",
+      file=sys.stderr)
+
+with open(outfile, "wb") as f:
+    try:
+        while True:
+            data = ser.read(256)
+            if data:
+                f.write(data)
+                f.flush()
+                sys.stdout.buffer.write(data)
+                sys.stdout.buffer.flush()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        ser.close()


### PR DESCRIPTION
## Summary

Large but coherent branch, three commits:

- `673d968` — power-on hours odometer, single-task USB rework, messaging-pipeline hardening, multi-version build, FromISR correctness, RX-priority tuning.
- `b16e4b5` — gate the odometer behind `USE_POWER_HOURS` (default off) after a hardware constraint was found.
- `bdc67c2` — watchdog health gate behind `USE_WATCHDOG_HEALTH_GATE` (default off): pre-existing arrangement petted the watchdog from the PWM ISR regardless of scheduler health; the gate refreshes only when a lowest-priority heartbeat task has run, so a hung scheduler actually resets. Off by default, byte-for-byte original behavior when 0.

Builds clean across the full **hw2/hw3/hw4** matrix (both gate states); host unit tests pass (the pre-existing `test_analog_filter` ×2 / `test_message_parsing` ×1 failures are unrelated and confirmed present on clean `main`).

## What's in here

**USB subsystem — single-task owner (correctness).** TinyUSB is built `CFG_TUSB_OS=OPT_OS_NONE`, only safe when one context drives the stack + CDC writes. Replaced the timer-daemon `tud_task()` + separate writer-task design (a real cross-context / ISR race) with one `usb_device_task` that owns every `tud_*` call: services `tud_task()`, drains the outbound queue with bounded burst + partial-write resume + stuck-message drop, monitors connection. Mutex/timers/`cdc_send` removed.

**Messaging pipeline — never block, never stall.** `send_to_controller` and the transport hand-offs are non-blocking with counted drops (`OUT_DROP`/`IN_DROP` in STATS) instead of a 10 ms block that could feed back into a timer-daemon stall. Fixed: a stack-overflow VLA in `tud_cdc_rx_cb`, a blank-line `break` that discarded queued inbound commands, a max-length framing loss, and a heap over-read in `send_to_controller`. `_Static_assert` couples queue/buffer sizes.

**FromISR correctness.** `*FromISR` queue APIs were being called from task context (logging, `tud_cdc_rx_cb`). Logging is now context-aware (real ISR vs task); task-context sites use the task API; dead `is_safe_to_enqueue_*` helpers removed. Genuine-ISR sites untouched.

**Real-time RX priority.** The standard-servo path has no control task (the PWM-wrap ISR consumes `motor_map[].requested_position` directly), so receiving/parsing host position commands every 20 ms is the latency-critical path. The inbound parse chain moved from priority 1 to `INCOMING_RX_TASK_PRIORITY` (5), above the USB and dxl tasks. Priority map documented in `config.h`.

**Multi-version build.** `CC_VERx` moved from a global define to per-target; the default build now produces hw2/hw3/hw4. A single `HARDWARE_VERSION` still narrows to one (back-compatible with CLion/CI).

**Power-on hours odometer (feature — gated off).** Two lifetime counters (uptime, motor-powered time) in a CRC-16 + sequence wear-leveled EEPROM ring; pure logic host-unit-tested. **Gated behind `USE_POWER_HOURS`, default 0**: the board's 24FC256 has WP tied to 3V3 (active-high write-protect), so the EEPROM is read-only at runtime on current hardware — confirmed by a ~10 h run then reboot (`UP_HRS` came back 0). Re-enable on a board revision where WP is GPIO-controlled; the path back on is documented at the `USE_POWER_HOURS` define.

**Watchdog health gate (infrastructure — gated off).** The PWM-wrap ISR refreshes the hardware watchdog, but that ISR runs off the PWM hardware IRQ independent of the FreeRTOS scheduler — so a fully deadlocked firmware still gets petted and never resets. Added a lowest-priority heartbeat task that proves the scheduler is alive; the ISR's refresh is now gated on a fresh heartbeat since the last refresh. Gates purely on scheduler liveness (never host/comms activity), so a legitimately idle creature is not reset. Behind `USE_WATCHDOG_HEALTH_GATE`, default 0; when 0, behavior is byte-for-byte the original unconditional refresh. ISR change is a one-token swap (`watchdog_update()` → `watchdog_feed()`) plus an include — gate policy lives entirely in the watchdog module.

## Debugging notes (so the changes aren't mistaken for noise)

Two long investigations both root-caused to **non-firmware** causes:

- A reported USB "message splice" survived three different TX rewrites; a raw byte-faithful capture proved the firmware's CDC stream is byte-perfect — it was **Serial.app** (a macOS GUI terminal) mangling bursty tab-delimited output. The USB/pipeline changes here stand on their own correctness merit.
- The odometer "persistence failure" was the **hardware EEPROM write-protect** above, not a logic bug.

A byte-faithful capture helper (`tools/raw_cdc_capture.py`) is included for future host-vs-firmware localization.

## Not in scope / follow-ups

- **Production soak still pending** — verified by build + unit tests + a clean ~10 h Linux capture, and the Dynamixel bus enumerates correctly on real hw4 hardware. Not yet a long production soak.
- `OPT_OS_FREERTOS` migration (event-driven RX) is designed and written up in `docs/opt-os-freertos-migration.md` — deliberately a separate, hardware-verified follow-up.
- CC_VER2 / UART path left as-is (deprecated; still compiles).
- Odometer stays off until the WP-GPIO board revision.
- Watchdog gate stays off until the deliberate-hang validation test on bench (procedure documented in the commit message and at the `USE_WATCHDOG_HEALTH_GATE` define).

## Test status

- Full hw2/hw3/hw4 matrix: builds clean (12 targets). Watchdog gate also verified to compile in the ON state.
- Host unit tests: `test_eeprom_hours` 7/7, `test_dynamixel_protocol` 13/13, others green. Pre-existing unrelated failures (`test_analog_filter` ×2, `test_message_parsing` ×1) confirmed on clean `main`.
- Real hardware: hw4 controller boots and the Dynamixel bus scan enumerates servos at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
