### PR TITLE
Handle SIGTERM so the controller actually stops under systemd

### DIFF
--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
 
 project(creature-controller
-        VERSION "4.0.0"
+        VERSION "4.0.1"
         DESCRIPTION "April's Creature Workshop Controller"
         HOMEPAGE_URL https://github.com/opsnlops/creature-controller
         LANGUAGES C CXX)

--- a/controller/src/audio/OpusRtpAudioClient.cpp
+++ b/controller/src/audio/OpusRtpAudioClient.cpp
@@ -202,6 +202,9 @@ void OpusRtpAudioClient::run() {
     setThreadName("opus-rtp-main");
 
     /* Initialize SDL Audio */
+    // Prevent SDL from installing SIGINT/SIGTERM handlers that swallow signals
+    // before our own handler can request shutdown (matters under systemd).
+    SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
     SDL_InitSubSystem(SDL_INIT_AUDIO);
     SDL_AudioSpec want{}, have{};
     want.freq = SAMPLE_RATE;
@@ -209,8 +212,8 @@ void OpusRtpAudioClient::run() {
     want.format = AUDIO_S16SYS;
     want.samples = SDL_BUFFER_FRAMES;
     // Get the device name for the specified device index
-    const char* deviceName = nullptr;
-    
+    const char *deviceName = nullptr;
+
     // Check if we have a valid device index (from --list-sound-devices output)
     int numDevices = SDL_GetNumAudioDevices(0);
     if (audioDeviceIndex_ < numDevices) {
@@ -221,8 +224,8 @@ void OpusRtpAudioClient::run() {
             log_->warn("Audio device {} name not available, trying by index", audioDeviceIndex_);
         }
     } else if (audioDeviceIndex_ > 0) {
-        log_->warn("Audio device {} not found (only {} devices available), using default", 
-                   audioDeviceIndex_, numDevices);
+        log_->warn("Audio device {} not found (only {} devices available), using default", audioDeviceIndex_,
+                   numDevices);
     } else {
         log_->info("Using default audio device");
     }

--- a/controller/src/config/UARTDevice.h
+++ b/controller/src/config/UARTDevice.h
@@ -45,9 +45,9 @@ class UARTDevice {
     void setEnabled(bool _enabled);
 
   private:
-    bool enabled;
+    bool enabled = false;
     std::string deviceNode;
-    module_name module;
+    module_name module = invalid_module;
 
     std::shared_ptr<Logger> logger;
 };

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -51,27 +51,31 @@
 // Default to not shutting down
 std::atomic<bool> shutdown_requested(false);
 
-// Track SIGINT signals for fail-safe mechanism
-std::atomic<int> sigint_count(0);
+// Track shutdown signals for fail-safe mechanism
+std::atomic<int> shutdown_signal_count(0);
 
 /**
  * @brief Signal handler to gracefully shutdown the application
- * @param signal The received signal
+ * @param signal The received signal (SIGINT or SIGTERM)
  */
 void signal_handler(int signal) {
-    if (signal == SIGINT) {
-        int current_count = sigint_count.fetch_add(1) + 1;
+    if (signal != SIGINT && signal != SIGTERM) {
+        return;
+    }
 
-        if (current_count == 1) {
-            // First SIGINT - start graceful shutdown
-            std::cerr << "Caught SIGINT, requesting graceful shutdown..." << std::endl;
-            std::cerr << "(Press Ctrl+C again for immediate hard shutdown)" << std::endl;
-            shutdown_requested.store(true);
-        } else {
-            // Second or subsequent SIGINT - perform immediate hard shutdown
-            std::cerr << "Second SIGINT received, performing immediate hard shutdown..." << std::endl;
-            std::_Exit(EXIT_FAILURE);
-        }
+    const char *name = (signal == SIGINT) ? "SIGINT" : "SIGTERM";
+    int current_count = shutdown_signal_count.fetch_add(1) + 1;
+
+    if (current_count == 1) {
+        // First shutdown signal - start graceful shutdown
+        std::cerr << "Caught " << name << ", requesting graceful shutdown..." << std::endl;
+        std::cerr << "(Send another shutdown signal for immediate hard shutdown)" << std::endl;
+        shutdown_requested.store(true);
+    } else {
+        // Second or subsequent shutdown signal - perform immediate hard shutdown
+        std::cerr << "Second shutdown signal (" << name << ") received, performing immediate hard shutdown..."
+                  << std::endl;
+        std::_Exit(EXIT_FAILURE);
     }
 }
 
@@ -273,8 +277,10 @@ int main(int argc, char **argv) {
     using creatures::io::Message;
     using creatures::server::ServerConnection;
 
-    // Fire up the signal handlers
+    // Fire up the signal handlers. SIGTERM is what systemd sends on `systemctl stop`;
+    // without an explicit handler, SDL grabs it during SDL_InitSubSystem and swallows it.
     std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
 
     std::string version = fmt::format("{}.{}.{}", CREATURE_CONTROLLER_VERSION_MAJOR, CREATURE_CONTROLLER_VERSION_MINOR,
                                       CREATURE_CONTROLLER_VERSION_PATCH);

--- a/controller/tests/SerialHandler_test.cpp
+++ b/controller/tests/SerialHandler_test.cpp
@@ -1,63 +1,65 @@
-#include <gtest/gtest.h>
+#include <stdexcept>
+
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include "io/Message.h"
 #include "io/SerialHandler.h"
-#include "io/SerialException.h"
-#include "util/MessageQueue.h"
 #include "mocks/logging/MockLogger.h"
+#include "util/MessageQueue.h"
 
 extern std::atomic<bool> shutdown_requested;
 
 namespace creatures {
 
-    // There isn't a clean way to mock a serial device in a unit test
+// There isn't a clean way to mock a serial device in a unit test
 //    TEST(SerialOutput, CreateSerialOutput_ValidDevice) {
 //        auto logger = std::make_shared<NiceMockLogger>();
 //        auto outputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
 //        auto inputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
 //
 //        EXPECT_NO_THROW({
-//                            auto serialOutput = SerialHandler(logger, "/dev/null", UARTDevice::A, outputQueue, inputQueue);
+//                            auto serialOutput = SerialHandler(logger, "/dev/null", UARTDevice::A, outputQueue,
+//                            inputQueue);
 //                        });
 //    }
 
-    TEST(SerialOutput, CreateSerialOutput_DeviceDoesNotExist) {
-        auto logger = std::make_shared<NiceMockLogger>();
-        auto outputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
-        auto inputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
+// Bad device nodes are no longer fatal at construction time; the constructor logs and
+// the caller learns about the failure when start() / setupSerialPort() returns an error
+// Result. These tests pin that contract.
+TEST(SerialOutput, CreateSerialOutput_DeviceDoesNotExist_IsNonFatal) {
+    auto logger = std::make_shared<NiceMockLogger>();
+    auto outputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
+    auto inputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
 
-        EXPECT_THROW({
-                         auto serialOutput = SerialHandler(logger, "", UARTDevice::A, outputQueue, inputQueue);
-                     }, SerialException);
-    }
+    EXPECT_NO_THROW({ auto serialOutput = SerialHandler(logger, "", UARTDevice::A, outputQueue, inputQueue); });
+}
 
-    TEST(SerialOutput, CreateSerialOutput_DeviceNotCharacterDevice) {
-        auto logger = std::make_shared<NiceMockLogger>();
-        auto outputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
-        auto inputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
+TEST(SerialOutput, CreateSerialOutput_DeviceNotCharacterDevice_IsNonFatal) {
+    auto logger = std::make_shared<NiceMockLogger>();
+    auto outputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
+    auto inputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
 
-        EXPECT_THROW({
-                         auto serialOutput = SerialHandler(logger, "/", UARTDevice::A, outputQueue, inputQueue);
-                     }, SerialException);
-    }
+    EXPECT_NO_THROW({ auto serialOutput = SerialHandler(logger, "/", UARTDevice::A, outputQueue, inputQueue); });
+}
 
-    TEST(SerialOutput, CreateSerialOutput_InvalidOutputQueue) {
-        auto logger = std::make_shared<NiceMockLogger>();
-        auto inputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
+// Null queues are still a programming error and surface as std::invalid_argument.
+TEST(SerialOutput, CreateSerialOutput_InvalidOutputQueue) {
+    auto logger = std::make_shared<NiceMockLogger>();
+    auto inputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
 
-        EXPECT_THROW({
-                         auto serialOutput = SerialHandler(logger, "/dev/null", UARTDevice::A, nullptr, inputQueue);
-                     }, SerialException);
-    }
+    EXPECT_THROW(
+        { auto serialOutput = SerialHandler(logger, "/dev/null", UARTDevice::A, nullptr, inputQueue); },
+        std::invalid_argument);
+}
 
-    TEST(SerialOutput, CreateSerialOutput_InvalidInputQueue) {
-        auto logger = std::make_shared<NiceMockLogger>();
-        auto outputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
+TEST(SerialOutput, CreateSerialOutput_InvalidInputQueue) {
+    auto logger = std::make_shared<NiceMockLogger>();
+    auto outputQueue = std::make_shared<MessageQueue<creatures::io::Message>>();
 
-        EXPECT_THROW({
-                         auto serialOutput = SerialHandler(logger, "/dev/null", UARTDevice::A, outputQueue, nullptr);
-                     }, SerialException);
-    }
+    EXPECT_THROW(
+        { auto serialOutput = SerialHandler(logger, "/dev/null", UARTDevice::A, outputQueue, nullptr); },
+        std::invalid_argument);
+}
 
 } // namespace creatures


### PR DESCRIPTION
## Summary

- `systemctl stop` was hanging because nothing handled SIGTERM — SDL grabs SIGTERM during `SDL_InitSubSystem(SDL_INIT_AUDIO)` and silently swallows it, so the controller ran until systemd's SIGKILL (which left USB/audio state wedged enough that a host reboot was the user-visible "fix"). Register `signal_handler` for SIGTERM and set `SDL_HINT_NO_SIGNAL_HANDLERS=1` so SDL stays out of signal handling. Bumps to `4.0.1`.
- Refresh `SerialHandler_test.cpp` so the 4 failing tests align with the constructor's current contract (non-fatal device-node errors, `std::invalid_argument` for null queues) — drift dates to `be3c366`.
- Fix undefined behavior in `UARTDevice`: default ctor was leaving `enabled` (bool) and `module` (enum) uninitialized. Test `ConstructorInitializesDisabledState` passed locally where the stack happened to be zeroed and failed in Docker. Added in-class default member initializers.

## Test plan

- [ ] Confirm `cmake --build` succeeds against the changed files.
- [ ] Run the gtest suite — the previously-failing `SerialOutput.*` and `UARTDeviceTest.ConstructorInitializesDisabledState` should now pass.
- [ ] On the target host, deploy and run via `systemd-run` (or systemd unit). Issue `systemctl stop`; service should log `Caught SIGTERM, requesting graceful shutdown...` and exit gracefully within a couple of seconds — no `TimeoutStopSec` wait, no SIGKILL.
- [ ] Sanity check: Ctrl+C in an interactive run still triggers graceful shutdown (SIGINT path unchanged in behavior, only refactored to share the handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)