### PR TITLE
2.8.8: keep vendored deps' install() rules out of the .deb (production hotfix)

### DIFF
--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
 
 project(creature-controller
-        VERSION "2.8.7"
+        VERSION "2.8.8"
         DESCRIPTION "April's Creature Workshop Controller"
         HOMEPAGE_URL https://github.com/opsnlops/creature-controller
         LANGUAGES C CXX)
@@ -62,6 +62,7 @@ FetchContent_MakeAvailable(argparse)
 FetchContent_Declare(
         googletest
         URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+        EXCLUDE_FROM_ALL   # keep googletest's install() rules out of our .deb
 )
 FetchContent_MakeAvailable(googletest)
 
@@ -70,6 +71,7 @@ FetchContent_Declare(
         uvgrtp
         GIT_REPOSITORY https://github.com/ultravideo/uvgRTP.git
         GIT_TAG        v3.1.6
+        EXCLUDE_FROM_ALL   # keep uvgRTP's install() rules out of our .deb (collided with creature-server)
 )
 FetchContent_MakeAvailable(uvgrtp)
 
@@ -84,6 +86,7 @@ FetchContent_Declare(
         opus
         GIT_REPOSITORY  https://github.com/xiph/opus.git
         GIT_TAG         v1.5.2
+        EXCLUDE_FROM_ALL   # keep Opus' install() rules (headers, .a, cmake configs, .pc) out of our .deb
 )
 FetchContent_MakeAvailable(opus)
 # Optimise Opus even when the rest of the build is Debug
@@ -115,6 +118,7 @@ FetchContent_Declare(
         ixwebsocket
         GIT_REPOSITORY https://github.com/machinezone/IXWebSocket.git
         GIT_TAG        v11.4.5
+        EXCLUDE_FROM_ALL   # keep IXWebSocket's install() rules out of our .deb
 )
 FetchContent_MakeAvailable(ixwebsocket)
 


### PR DESCRIPTION
## What
Production hotfix on the 2.8.x line (branched from `3d0724e`, the 2.8.7 tip — versions match deployed production: opus 1.5.2, spdlog 1.11.0, fmt 9.1.0). Adds `EXCLUDE_FROM_ALL` to the **opus**, **uvgrtp**, and **ixwebsocket** FetchContent declares (and **googletest** defensively), and bumps `2.8.7` → `2.8.8`.

## Why
The deployed `2.8.7` controller `.deb` shipped `/usr/include/opus/*` and the uvgRTP headers/cmake configs because FetchContent ran each dependency's own `install()` rules during cpack. dpkg refuses to let two packages own the same file, so installing `creature-controller` alongside `creature-server` (which ships the identical files) failed to unpack on a shared machine.

## Verification
Built the real arm64 `.deb` from this branch and inspected it:
- `creature-controller_2.8.8-*_arm64.deb` — contains `/bin/creature-controller` (1.87 MB binary) and **nothing else**
- Zero opus/uvgrtp/ixwebsocket/gtest headers, `.a`, cmake configs, or `.pc`

Carries **only** the packaging cleanup — none of the 4.x dev work that's on `main`. Merge here, tag `2.8.8`, and deploy to clear the collision in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)