### PR TITLE
controller: also exclude googletest from the .deb

### DIFF
--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -60,6 +60,7 @@ FetchContent_MakeAvailable(argparse)
 FetchContent_Declare(
         googletest
         URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
+        EXCLUDE_FROM_ALL   # v1.17 installs as a subproject; keep its headers/.a/cmake/.pc out of our .deb
 )
 FetchContent_MakeAvailable(googletest)
 


### PR DESCRIPTION
## What
Adds `EXCLUDE_FROM_ALL` to the **googletest** FetchContent declare. Completes the opus/uvgrtp/ixwebsocket exclusion already on `main` (`4c15e06`).

## Why
The real arm64 package build revealed googletest still leaking ~60 dev files (gtest/gmock headers, static libs, cmake configs, `.pc`) into `creature-controller`. googletest **v1.17** — unlike the v1.14 the server pins — registers `install()` rules even as a FetchContent subproject, and they live in nested `googletest/googlemock` subdirs that a top-level `cmake_install` scan misses (which is why static analysis didn't catch it; the actual `.deb` did).

`EXCLUDE_FROM_ALL`'s "or below" directory-property semantics drop the nested install rules. The test target still builds — it links gtest directly, so the dependency is still compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)